### PR TITLE
fix error jpg color

### DIFF
--- a/fastbuilder/builder/paint.go
+++ b/fastbuilder/builder/paint.go
@@ -34,9 +34,9 @@ func Paint(config *types.MainConfig, blc chan *types.Module) error {
 		for y := 0; y < Y; y++ {
 			r, g, b, _ := img.At(x, y).RGBA()
 			c := colorful.Color{
-				R: float64(r & 0xff),
-				G: float64(g & 0xff),
-				B: float64(b & 0xff),
+				R: float64(r >> 8),
+				G: float64(g >> 8),
+				B: float64(b >> 8),
 			}
 			switch facing {
 			default:


### PR DESCRIPTION
it seem that the alpha channel take 8 bytes, so we cannot get correct jpg value if &0xff, I am sure, but you can check this:

``` go
package main

import (
	"github.com/disintegration/imaging"
	"image"
	"image/color"
	"image/png"
	"os"
)

func main() {
	jpgImg, err := imaging.Open("in.PNG")
	if err != nil {
		panic(err)
	}
	Max := jpgImg.Bounds().Max
	X, Y := Max.X, Max.Y
	upLeft := image.Point{0, 0}
	lowRight := image.Point{X, Y}
	pngImg := image.NewRGBA(image.Rectangle{upLeft, lowRight})
	
	for x := 0; x < X; x++ {
		for y := 0; y < Y; y++ {
			r, g, b, _ := jpgImg.At(x, y).RGBA()
			pngImg.Set(x, y, color.RGBA{uint8(r >> 8), uint8(g >> 8), uint8(b >> 8), 0xff})
		}
	}

	// Encode as PNG.
	f, _ := os.Create("out.png")
	png.Encode(f, pngImg)
}
```