### PR TITLE
在 FB 的终端 增加一个help 命令

### DIFF
--- a/cdocs/README-cn.md
+++ b/cdocs/README-cn.md
@@ -195,6 +195,12 @@ task setdelaythreshold <taskID> <threshold:int> # 设定某个任务的阈值（
 
 ##### 功能命令
 
+- 获取 FastBuilder 的帮助:
+  ```shell
+  help 1 # 获取 FB 的帮助菜单
+  help <命令:str> # 获取 FB内置的命令帮助,例如: help set  
+  ```
+
 - 设置空间原点/终点(终点并不一定是必要的)：
 
   ```shell
@@ -228,13 +234,6 @@ task setdelaythreshold <taskID> <threshold:int> # 设定某个任务的阈值（
   lang
   ```
 
-* 打开FastBuilder控制菜单
-
-  ```
-  menu
-  ```
-
-  
 
 ##### 几何命令
 
@@ -327,15 +326,6 @@ FastBuilder具备在空间中构造简单几何体的功能（如圆,圈,球,线
   ```
 
 * 用`bdump`命令对其进行导入操作。
-
-##### 世界聊天
-
-世界聊天可以让您与其他在线的FastBuilder用户聊天，您可以在用户中心开启/关闭它。用法如下:
-
-```shell
-> 消息
-> 匿名消息
-```
 
 ##### 命令执行
 

--- a/fastbuilder/core/core.go
+++ b/fastbuilder/core/core.go
@@ -320,29 +320,6 @@ func EnterReadlineThread(env *environment.PBEnvironment, breaker chan struct{}) 
 				fbcl.WorldChat(umsg)
 			}
 		}
-		Expend_cmd := strings.Split(cmd, " ")
-		if Expend_cmd[0] == "help" {
-			// 帮助菜单的构建
-			if len(Expend_cmd) == 1 {
-				// 默认查询
-
-				fmt.Println(pterm.Green(I18n.T(I18n.Menu_Tip_Cmd_MC_Command)) + " " + pterm.Cyan(I18n.T(I18n.Menu_Tip_MC_Command)))
-				fmt.Println(pterm.Green(I18n.T(I18n.Menu_Tip_Cmd_FB_World_Chat)) + " " + pterm.Cyan(I18n.T(I18n.Menu_Tip_FB_World_Chat)))
-				fmt.Println(pterm.Green(I18n.T(I18n.Menu_Tip_Cmd_Exit)) + " " + pterm.Cyan(I18n.T(I18n.Menu_Tip_Exit)))
-				fmt.Println(pterm.Green(I18n.T(I18n.Menu_Tip_Cmd_Help)) + " " + pterm.Cyan(I18n.T(I18n.Menu_Tip_Help)))
-				fmt.Println(pterm.Green(I18n.T(I18n.Menu_Tip_Cmd_Lang)) + " " + pterm.Cyan(I18n.T(I18n.Menu_Tip_Lang)))
-				fmt.Println(pterm.Green(I18n.T(I18n.Menu_Tip_Cmd_logout)) + " " + pterm.Cyan(I18n.T(I18n.Menu_Tip_logout)))
-				fmt.Println(pterm.Green(I18n.T(I18n.Menu_Tip_Cmd_Progress)) + " " + pterm.Cyan(I18n.T(I18n.Menu_Tip_Progress)))
-				fmt.Println(pterm.Green(I18n.T(I18n.Menu_Tip_Cmd_Round)) + " " + pterm.Cyan(I18n.T(I18n.Menu_Tip_Round)))
-				fmt.Println(pterm.Green(I18n.T(I18n.Menu_Tip_Cmd_Get)) + " " + pterm.Cyan(I18n.T(I18n.Menu_Tip_Get)))
-				fmt.Println(pterm.Green(I18n.T(I18n.Menu_Tip_Cmd_Set)) + " " + pterm.Cyan(I18n.T(I18n.Menu_Tip_Set)))
-				fmt.Println(pterm.Green(I18n.T(I18n.Menu_Tip_Cmd_Task)) + " " + pterm.Cyan(I18n.T(I18n.Menu_Tip_Task)))
-				fmt.Println(pterm.Green(I18n.T(I18n.Menu_Tip_Cmd_Setend)) + " " + pterm.Cyan(I18n.T(I18n.Menu_Tip_Setend)))
-				fmt.Println(pterm.Green(I18n.T(I18n.Menu_Tip_Cmd_delay)) + " " + pterm.Cyan(I18n.T(I18n.Menu_Tip_delay)))
-
-			}
-		}
-
 		functionHolder.Process(cmd)
 	}
 }

--- a/fastbuilder/function/internal.go
+++ b/fastbuilder/function/internal.go
@@ -1,434 +1,454 @@
 package function
 
 import (
-	"os"
 	"fmt"
+	"os"
 	"path/filepath"
 	"phoenixbuilder/bridge/bridge_fmt"
-	"phoenixbuilder/fastbuilder/types"
-	"phoenixbuilder/fastbuilder/configuration"
-	fbtask "phoenixbuilder/fastbuilder/task"
 	"phoenixbuilder/fastbuilder/builder"
-	"phoenixbuilder/minecraft"
-	"phoenixbuilder/fastbuilder/i18n"
+	"phoenixbuilder/fastbuilder/configuration"
 	"phoenixbuilder/fastbuilder/environment"
+	I18n "phoenixbuilder/fastbuilder/i18n"
+	fbtask "phoenixbuilder/fastbuilder/task"
+	"phoenixbuilder/fastbuilder/types"
 	"phoenixbuilder/io/special_tasks"
+	"phoenixbuilder/minecraft"
+
+	"github.com/pterm/pterm"
 )
 
-
-
 func InitInternalFunctions(fh *FunctionHolder) {
-	delayEnumId:=fh.RegisterEnum("continuous, discrete, none",types.ParseDelayMode,types.DelayModeInvalid)
-	fh.RegisterFunction(&Function {
-		Name: "exit",
-		OwnedKeywords: []string {"exit","fbexit"},
-		FunctionType:FunctionTypeSimple,
+	delayEnumId := fh.RegisterEnum("continuous, discrete, none", types.ParseDelayMode, types.DelayModeInvalid)
+	fh.RegisterFunction(&Function{
+		Name:          "exit",
+		OwnedKeywords: []string{"exit", "fbexit"},
+		FunctionType:  FunctionTypeSimple,
 		SFMinSliceLen: 1,
-		FunctionContent: func(env *environment.PBEnvironment,_ []interface{}) {
+		FunctionContent: func(env *environment.PBEnvironment, _ []interface{}) {
 			env.CommandSender.Output(I18n.T(I18n.QuitCorrectly))
-			bridge_fmt.Printf("%s\n",I18n.T(I18n.QuitCorrectly))
+			bridge_fmt.Printf("%s\n", I18n.T(I18n.QuitCorrectly))
 			env.Connection.(*minecraft.Conn).Close()
 			os.Exit(0)
 		},
 	})
-	fh.RegisterFunction(&Function {
-		Name: "logout",
-		OwnedKeywords: []string { "logout" },
-		FunctionType: FunctionTypeSimple,
+	fh.RegisterFunction(&Function{
+		Name:          "help",
+		OwnedKeywords: []string{"help"},
+		FunctionType:  FunctionTypeSimple,
 		SFMinSliceLen: 1,
-		FunctionContent: func(env *environment.PBEnvironment,_ []interface{}) {
-			conn:=env.Connection.(*minecraft.Conn)
-			commandSender:=env.CommandSender
+		FunctionContent: func(env *environment.PBEnvironment, _ []interface{}) {
+			fmt.Println(pterm.Green(I18n.T(I18n.Menu_Tip_Cmd_MC_Command)) + " " + pterm.Cyan(I18n.T(I18n.Menu_Tip_MC_Command)))
+			fmt.Println(pterm.Green(I18n.T(I18n.Menu_Tip_Cmd_FB_World_Chat)) + " " + pterm.Cyan(I18n.T(I18n.Menu_Tip_FB_World_Chat)))
+			fmt.Println(pterm.Green(I18n.T(I18n.Menu_Tip_Cmd_Exit)) + " " + pterm.Cyan(I18n.T(I18n.Menu_Tip_Exit)))
+			fmt.Println(pterm.Green(I18n.T(I18n.Menu_Tip_Cmd_Help)) + " " + pterm.Cyan(I18n.T(I18n.Menu_Tip_Help)))
+			fmt.Println(pterm.Green(I18n.T(I18n.Menu_Tip_Cmd_Lang)) + " " + pterm.Cyan(I18n.T(I18n.Menu_Tip_Lang)))
+			fmt.Println(pterm.Green(I18n.T(I18n.Menu_Tip_Cmd_logout)) + " " + pterm.Cyan(I18n.T(I18n.Menu_Tip_logout)))
+			fmt.Println(pterm.Green(I18n.T(I18n.Menu_Tip_Cmd_Progress)) + " " + pterm.Cyan(I18n.T(I18n.Menu_Tip_Progress)))
+			fmt.Println(pterm.Green(I18n.T(I18n.Menu_Tip_Cmd_Round)) + " " + pterm.Cyan(I18n.T(I18n.Menu_Tip_Round)))
+			fmt.Println(pterm.Green(I18n.T(I18n.Menu_Tip_Cmd_Get)) + " " + pterm.Cyan(I18n.T(I18n.Menu_Tip_Get)))
+			fmt.Println(pterm.Green(I18n.T(I18n.Menu_Tip_Cmd_Set)) + " " + pterm.Cyan(I18n.T(I18n.Menu_Tip_Set)))
+			fmt.Println(pterm.Green(I18n.T(I18n.Menu_Tip_Cmd_Task)) + " " + pterm.Cyan(I18n.T(I18n.Menu_Tip_Task)))
+			fmt.Println(pterm.Green(I18n.T(I18n.Menu_Tip_Cmd_Setend)) + " " + pterm.Cyan(I18n.T(I18n.Menu_Tip_Setend)))
+			fmt.Println(pterm.Green(I18n.T(I18n.Menu_Tip_Cmd_delay)) + " " + pterm.Cyan(I18n.T(I18n.Menu_Tip_delay)))
+		},
+	})
+	fh.RegisterFunction(&Function{
+		Name:          "logout",
+		OwnedKeywords: []string{"logout"},
+		FunctionType:  FunctionTypeSimple,
+		SFMinSliceLen: 1,
+		FunctionContent: func(env *environment.PBEnvironment, _ []interface{}) {
+			conn := env.Connection.(*minecraft.Conn)
+			commandSender := env.CommandSender
 			homedir, err := os.UserHomeDir()
 			if err != nil {
 				bridge_fmt.Println(I18n.T(I18n.Warning_UserHomeDir))
-				homedir="."
+				homedir = "."
 			}
 			fbconfigdir := filepath.Join(homedir, ".config/fastbuilder")
 			os.MkdirAll(fbconfigdir, 0755)
-			token := filepath.Join(fbconfigdir,"fbtoken")
+			token := filepath.Join(fbconfigdir, "fbtoken")
 			err = os.Remove(token)
-			if(err!=nil) {
-				commandSender.Output(fmt.Sprintf(I18n.T(I18n.FBUC_Token_ErrOnRemove),err))
+			if err != nil {
+				commandSender.Output(fmt.Sprintf(I18n.T(I18n.FBUC_Token_ErrOnRemove), err))
 				return
 			}
 			commandSender.Output(I18n.T(I18n.Logout_Done))
 			commandSender.Output(I18n.T(I18n.QuitCorrectly))
-			bridge_fmt.Printf("%s\n",I18n.T(I18n.QuitCorrectly))
+			bridge_fmt.Printf("%s\n", I18n.T(I18n.QuitCorrectly))
 			conn.Close()
 			os.Exit(0)
 		},
 	})
-	fh.RegisterFunction(&Function {
-		Name: "reselect language",
-		OwnedKeywords: []string { "lang" },
-		FunctionType: FunctionTypeSimple,
+	fh.RegisterFunction(&Function{
+		Name:          "reselect language",
+		OwnedKeywords: []string{"lang"},
+		FunctionType:  FunctionTypeSimple,
 		SFMinSliceLen: 1,
-		FunctionContent: func(env *environment.PBEnvironment,_ []interface{}) {
+		FunctionContent: func(env *environment.PBEnvironment, _ []interface{}) {
 			env.CommandSender.Output(I18n.T(I18n.SelectLanguageOnConsole))
 			I18n.SelectLanguage()
 			I18n.UpdateLanguage()
 		},
 	})
-	fh.RegisterFunction(&Function {
-		Name: "set",
-		OwnedKeywords: []string {"set"},
-		FunctionType:FunctionTypeSimple,
-		SFMinSliceLen:4,
-		SFArgumentTypes: []byte {SimpleFunctionArgumentInt,SimpleFunctionArgumentInt,SimpleFunctionArgumentInt},
-		FunctionContent: func(env *environment.PBEnvironment,args []interface{}) {
+	fh.RegisterFunction(&Function{
+		Name:            "set",
+		OwnedKeywords:   []string{"set"},
+		FunctionType:    FunctionTypeSimple,
+		SFMinSliceLen:   4,
+		SFArgumentTypes: []byte{SimpleFunctionArgumentInt, SimpleFunctionArgumentInt, SimpleFunctionArgumentInt},
+		FunctionContent: func(env *environment.PBEnvironment, args []interface{}) {
 			X, _ := args[0].(int)
 			Y, _ := args[1].(int)
 			Z, _ := args[2].(int)
-			configuration.GlobalFullConfig(env).Main().Position=types.Position {
+			configuration.GlobalFullConfig(env).Main().Position = types.Position{
 				X: X,
 				Y: Y,
 				Z: Z,
 			}
-			env.CommandSender.Output(fmt.Sprintf("%s: %d, %d, %d.",I18n.T(I18n.PositionSet),X,Y,Z))
+			env.CommandSender.Output(fmt.Sprintf("%s: %d, %d, %d.", I18n.T(I18n.PositionSet), X, Y, Z))
 		},
 	})
-	fh.RegisterFunction(&Function {
-		Name: "setend",
-		OwnedKeywords: []string {"setend"},
-		FunctionType:FunctionTypeSimple,
-		SFMinSliceLen:4,
-		SFArgumentTypes: []byte {SimpleFunctionArgumentInt,SimpleFunctionArgumentInt,SimpleFunctionArgumentInt},
-		FunctionContent: func(env *environment.PBEnvironment,args []interface{}) {
+	fh.RegisterFunction(&Function{
+		Name:            "setend",
+		OwnedKeywords:   []string{"setend"},
+		FunctionType:    FunctionTypeSimple,
+		SFMinSliceLen:   4,
+		SFArgumentTypes: []byte{SimpleFunctionArgumentInt, SimpleFunctionArgumentInt, SimpleFunctionArgumentInt},
+		FunctionContent: func(env *environment.PBEnvironment, args []interface{}) {
 			X, _ := args[0].(int)
 			Y, _ := args[1].(int)
 			Z, _ := args[2].(int)
-			configuration.GlobalFullConfig(env).Main().End=types.Position {
+			configuration.GlobalFullConfig(env).Main().End = types.Position{
 				X: X,
 				Y: Y,
 				Z: Z,
 			}
-			env.CommandSender.Output(fmt.Sprintf("%s: %d, %d, %d.",I18n.T(I18n.PositionSet_End),X,Y,Z))
+			env.CommandSender.Output(fmt.Sprintf("%s: %d, %d, %d.", I18n.T(I18n.PositionSet_End), X, Y, Z))
 		},
 	})
-	fh.RegisterFunction(&Function {
-		Name: "delay",
-		OwnedKeywords: []string {"delay"},
-		FunctionType: FunctionTypeContinue,
+	fh.RegisterFunction(&Function{
+		Name:          "delay",
+		OwnedKeywords: []string{"delay"},
+		FunctionType:  FunctionTypeContinue,
 		SFMinSliceLen: 3,
-		FunctionContent: map[string]*FunctionChainItem {
-			"set": &FunctionChainItem {
-				FunctionType: FunctionTypeSimple,
+		FunctionContent: map[string]*FunctionChainItem{
+			"set": &FunctionChainItem{
+				FunctionType:  FunctionTypeSimple,
 				ArgumentTypes: []byte{SimpleFunctionArgumentInt},
-				Content: func(env *environment.PBEnvironment, args []interface{}){
-					if configuration.GlobalFullConfig(env).Delay().DelayMode==types.DelayModeNone {
+				Content: func(env *environment.PBEnvironment, args []interface{}) {
+					if configuration.GlobalFullConfig(env).Delay().DelayMode == types.DelayModeNone {
 						env.CommandSender.Output(I18n.T(I18n.DelaySetUnavailableUnderNoneMode))
 						return
 					}
-					ms, _:=args[0].(int)
-					configuration.GlobalFullConfig(env).Delay().Delay=int64(ms)
+					ms, _ := args[0].(int)
+					configuration.GlobalFullConfig(env).Delay().Delay = int64(ms)
 					env.CommandSender.Output(fmt.Sprintf("%s: %d", I18n.T(I18n.DelaySet), ms))
 				},
 			},
-			"mode": &FunctionChainItem {
+			"mode": &FunctionChainItem{
 				FunctionType: FunctionTypeContinue,
-				Content: map[string]*FunctionChainItem {
-					"get": &FunctionChainItem {
+				Content: map[string]*FunctionChainItem{
+					"get": &FunctionChainItem{
 						FunctionType: FunctionTypeSimple,
-						Content: func(env *environment.PBEnvironment, _ []interface{}){
-							env.CommandSender.Output(fmt.Sprintf("%s: %s.",I18n.T(I18n.CurrentDefaultDelayMode),types.StrDelayMode(configuration.GlobalFullConfig(env).Delay().DelayMode)))
+						Content: func(env *environment.PBEnvironment, _ []interface{}) {
+							env.CommandSender.Output(fmt.Sprintf("%s: %s.", I18n.T(I18n.CurrentDefaultDelayMode), types.StrDelayMode(configuration.GlobalFullConfig(env).Delay().DelayMode)))
 						},
 					},
-					"set": &FunctionChainItem {
-						FunctionType: FunctionTypeSimple,
+					"set": &FunctionChainItem{
+						FunctionType:  FunctionTypeSimple,
 						ArgumentTypes: []byte{byte(delayEnumId)},
-						Content: func(env *environment.PBEnvironment, args []interface{}){
-							delaymode,_:=args[0].(byte)
-							configuration.GlobalFullConfig(env).Delay().DelayMode=delaymode
-							env.CommandSender.Output(fmt.Sprintf("%s: %s",I18n.T(I18n.DelayModeSet),types.StrDelayMode(delaymode)))
+						Content: func(env *environment.PBEnvironment, args []interface{}) {
+							delaymode, _ := args[0].(byte)
+							configuration.GlobalFullConfig(env).Delay().DelayMode = delaymode
+							env.CommandSender.Output(fmt.Sprintf("%s: %s", I18n.T(I18n.DelayModeSet), types.StrDelayMode(delaymode)))
 							if delaymode != types.DelayModeNone {
-								dl:=decideDelay(delaymode)
-								configuration.GlobalFullConfig(env).Delay().Delay=dl
-								env.CommandSender.Output(fmt.Sprintf(I18n.T(I18n.DelayModeSet_DelayAuto),dl))
+								dl := decideDelay(delaymode)
+								configuration.GlobalFullConfig(env).Delay().Delay = dl
+								env.CommandSender.Output(fmt.Sprintf(I18n.T(I18n.DelayModeSet_DelayAuto), dl))
 							}
-							if delaymode==types.DelayModeDiscrete {
-								configuration.GlobalFullConfig(env).Delay().DelayThreshold=decideDelayThreshold()
-								env.CommandSender.Output(fmt.Sprintf(I18n.T(I18n.DelayModeSet_ThresholdAuto),configuration.GlobalFullConfig(env).Delay().DelayThreshold))
+							if delaymode == types.DelayModeDiscrete {
+								configuration.GlobalFullConfig(env).Delay().DelayThreshold = decideDelayThreshold()
+								env.CommandSender.Output(fmt.Sprintf(I18n.T(I18n.DelayModeSet_ThresholdAuto), configuration.GlobalFullConfig(env).Delay().DelayThreshold))
 							}
 						},
 					},
 				},
 			},
-			"threshold": &FunctionChainItem {
-				FunctionType: FunctionTypeSimple,
+			"threshold": &FunctionChainItem{
+				FunctionType:  FunctionTypeSimple,
 				ArgumentTypes: []byte{SimpleFunctionArgumentInt},
-				Content: func(env *environment.PBEnvironment, args []interface{}){
+				Content: func(env *environment.PBEnvironment, args []interface{}) {
 					if configuration.GlobalFullConfig(env).Delay().DelayMode != types.DelayModeDiscrete {
 						env.CommandSender.Output(I18n.T(I18n.DelayThreshold_OnlyDiscrete))
 						return
 					}
 					thr, _ := args[0].(int)
-					configuration.GlobalFullConfig(env).Delay().DelayThreshold=thr
+					configuration.GlobalFullConfig(env).Delay().DelayThreshold = thr
 					env.CommandSender.Output(fmt.Sprintf(I18n.T(I18n.DelayThreshold_Set), thr))
 				},
 			},
 		},
 	})
-	fh.RegisterFunction(&Function {
-		Name: "get-pos",
-		OwnedKeywords: []string {"get"},
-		FunctionType:FunctionTypeContinue,
-		SFMinSliceLen:1,
-		FunctionContent: map[string]*FunctionChainItem {
-			"": &FunctionChainItem {
-				FunctionType: FunctionTypeSimple,
+	fh.RegisterFunction(&Function{
+		Name:          "get-pos",
+		OwnedKeywords: []string{"get"},
+		FunctionType:  FunctionTypeContinue,
+		SFMinSliceLen: 1,
+		FunctionContent: map[string]*FunctionChainItem{
+			"": &FunctionChainItem{
+				FunctionType:  FunctionTypeSimple,
 				ArgumentTypes: []byte{},
-				Content: func(env *environment.PBEnvironment,_ []interface{}) {
+				Content: func(env *environment.PBEnvironment, _ []interface{}) {
 					env.CommandSender.SendSizukanaCommand("gamerule sendcommandfeedback true")
-					env.CommandSender.SendCommand(fmt.Sprintf("execute @a[name=\"%s\"] ~ ~ ~ testforblock ~ ~ ~ air",env.RespondUser),configuration.ZeroId)
+					env.CommandSender.SendCommand(fmt.Sprintf("execute @a[name=\"%s\"] ~ ~ ~ testforblock ~ ~ ~ air", env.RespondUser), configuration.ZeroId)
 				},
 			},
-			"begin": &FunctionChainItem {
+			"begin": &FunctionChainItem{
 				FunctionType: FunctionTypeSimple,
-				Content: func(env *environment.PBEnvironment,_ []interface{}) {
+				Content: func(env *environment.PBEnvironment, _ []interface{}) {
 					env.CommandSender.SendSizukanaCommand("gamerule sendcommandfeedback true")
-					env.CommandSender.SendCommand(fmt.Sprintf("execute @a[name=\"%s\"] ~ ~ ~ testforblock ~ ~ ~ air",env.RespondUser),configuration.ZeroId)
+					env.CommandSender.SendCommand(fmt.Sprintf("execute @a[name=\"%s\"] ~ ~ ~ testforblock ~ ~ ~ air", env.RespondUser), configuration.ZeroId)
 				},
 			},
-			"end": &FunctionChainItem {
+			"end": &FunctionChainItem{
 				FunctionType: FunctionTypeSimple,
-				Content: func(env *environment.PBEnvironment,_ []interface{}) {
+				Content: func(env *environment.PBEnvironment, _ []interface{}) {
 					env.CommandSender.SendSizukanaCommand("gamerule sendcommandfeedback true")
-					env.CommandSender.SendCommand(fmt.Sprintf("execute @a[name=\"%s\"] ~ ~ ~ testforblock ~ ~ ~ air",env.RespondUser),configuration.OneId)
+					env.CommandSender.SendCommand(fmt.Sprintf("execute @a[name=\"%s\"] ~ ~ ~ testforblock ~ ~ ~ air", env.RespondUser), configuration.OneId)
 				},
 			},
 		},
 	})
-	fh.RegisterFunction(&Function {
-		Name: "task",
-		OwnedKeywords: []string {"task"},
-		FunctionType: FunctionTypeContinue,
-		SFMinSliceLen:2,
-		FunctionContent: map[string]*FunctionChainItem {
-			"list": &FunctionChainItem {
+	fh.RegisterFunction(&Function{
+		Name:          "task",
+		OwnedKeywords: []string{"task"},
+		FunctionType:  FunctionTypeContinue,
+		SFMinSliceLen: 2,
+		FunctionContent: map[string]*FunctionChainItem{
+			"list": &FunctionChainItem{
 				FunctionType: FunctionTypeSimple,
-				Content: func(env *environment.PBEnvironment,_ []interface{}) {
-					total:=0
+				Content: func(env *environment.PBEnvironment, _ []interface{}) {
+					total := 0
 					env.CommandSender.Output(I18n.T(I18n.CurrentTasks))
-					taskholder:=env.TaskHolder.(*fbtask.TaskHolder)
-					taskholder.TaskMap.Range(func (_tid interface{}, _v interface{}) bool {
-						tid,_:=_tid.(int64)
-						v,_:=_v.(*fbtask.Task)
-						dt:=-1
-						dv:=int64(-1)
-						if v.Config.Delay().DelayMode==types.DelayModeDiscrete {
-							dt=v.Config.Delay().DelayThreshold
+					taskholder := env.TaskHolder.(*fbtask.TaskHolder)
+					taskholder.TaskMap.Range(func(_tid interface{}, _v interface{}) bool {
+						tid, _ := _tid.(int64)
+						v, _ := _v.(*fbtask.Task)
+						dt := -1
+						dv := int64(-1)
+						if v.Config.Delay().DelayMode == types.DelayModeDiscrete {
+							dt = v.Config.Delay().DelayThreshold
 						}
-						if v.Config.Delay().DelayMode!=types.DelayModeNone {
-							dv=v.Config.Delay().Delay
+						if v.Config.Delay().DelayMode != types.DelayModeNone {
+							dv = v.Config.Delay().Delay
 						}
-						env.CommandSender.Output(fmt.Sprintf(I18n.T(I18n.TaskStateLine),tid,v.CommandLine,fbtask.GetStateDesc(v.State),dv,types.StrDelayMode(v.Config.Delay().DelayMode),dt))
+						env.CommandSender.Output(fmt.Sprintf(I18n.T(I18n.TaskStateLine), tid, v.CommandLine, fbtask.GetStateDesc(v.State), dv, types.StrDelayMode(v.Config.Delay().DelayMode), dt))
 						total++
 						return true
 					})
-					env.CommandSender.Output(fmt.Sprintf(I18n.T(I18n.TaskTotalCount),total))
+					env.CommandSender.Output(fmt.Sprintf(I18n.T(I18n.TaskTotalCount), total))
 				},
 			},
-			"pause": &FunctionChainItem {
-				FunctionType: FunctionTypeSimple,
+			"pause": &FunctionChainItem{
+				FunctionType:  FunctionTypeSimple,
 				ArgumentTypes: []byte{SimpleFunctionArgumentInt},
-				Content: func(env *environment.PBEnvironment,args []interface{}) {
+				Content: func(env *environment.PBEnvironment, args []interface{}) {
 					tid, _ := args[0].(int)
-					taskholder:=env.TaskHolder.(*fbtask.TaskHolder)
-					task:=taskholder.FindTask(int64(tid))
-					if task==nil {
+					taskholder := env.TaskHolder.(*fbtask.TaskHolder)
+					task := taskholder.FindTask(int64(tid))
+					if task == nil {
 						env.CommandSender.Output(I18n.T(I18n.TaskNotFoundMessage))
 						return
 					}
 					task.Pause()
-					env.CommandSender.Output(fmt.Sprintf(I18n.T(I18n.TaskPausedNotice),task.TaskId))
+					env.CommandSender.Output(fmt.Sprintf(I18n.T(I18n.TaskPausedNotice), task.TaskId))
 				},
 			},
-			"resume": &FunctionChainItem {
-				FunctionType: FunctionTypeSimple,
+			"resume": &FunctionChainItem{
+				FunctionType:  FunctionTypeSimple,
 				ArgumentTypes: []byte{SimpleFunctionArgumentInt},
-				Content: func(env *environment.PBEnvironment,args []interface{}) {
+				Content: func(env *environment.PBEnvironment, args []interface{}) {
 					tid, _ := args[0].(int)
-					taskholder:=env.TaskHolder.(*fbtask.TaskHolder)
-					task:=taskholder.FindTask(int64(tid))
-					if task==nil {
+					taskholder := env.TaskHolder.(*fbtask.TaskHolder)
+					task := taskholder.FindTask(int64(tid))
+					if task == nil {
 						env.CommandSender.Output(I18n.T(I18n.TaskNotFoundMessage))
 						return
 					}
 					task.Resume()
-					env.CommandSender.Output(fmt.Sprintf(I18n.T(I18n.TaskResumedNotice),task.TaskId))
+					env.CommandSender.Output(fmt.Sprintf(I18n.T(I18n.TaskResumedNotice), task.TaskId))
 				},
 			},
-			"break": &FunctionChainItem {
-				FunctionType: FunctionTypeSimple,
+			"break": &FunctionChainItem{
+				FunctionType:  FunctionTypeSimple,
 				ArgumentTypes: []byte{SimpleFunctionArgumentInt},
-				Content: func(env *environment.PBEnvironment,args []interface{}) {
+				Content: func(env *environment.PBEnvironment, args []interface{}) {
 					tid, _ := args[0].(int)
-					taskholder:=env.TaskHolder.(*fbtask.TaskHolder)
-					task:=taskholder.FindTask(int64(tid))
-					if task==nil {
+					taskholder := env.TaskHolder.(*fbtask.TaskHolder)
+					task := taskholder.FindTask(int64(tid))
+					if task == nil {
 						env.CommandSender.Output(I18n.T(I18n.TaskNotFoundMessage))
 						return
 					}
 					task.Break()
-					env.CommandSender.Output(fmt.Sprintf(I18n.T(I18n.TaskStoppedNotice),task.TaskId))
+					env.CommandSender.Output(fmt.Sprintf(I18n.T(I18n.TaskStoppedNotice), task.TaskId))
 				},
 			},
-			"setdelay": &FunctionChainItem {
-				FunctionType: FunctionTypeSimple,
-				ArgumentTypes: []byte {SimpleFunctionArgumentInt,SimpleFunctionArgumentInt},
-				Content: func(env *environment.PBEnvironment,args []interface{}) {
+			"setdelay": &FunctionChainItem{
+				FunctionType:  FunctionTypeSimple,
+				ArgumentTypes: []byte{SimpleFunctionArgumentInt, SimpleFunctionArgumentInt},
+				Content: func(env *environment.PBEnvironment, args []interface{}) {
 					tid, _ := args[0].(int)
 					del, _ := args[1].(int)
-					taskholder:=env.TaskHolder.(*fbtask.TaskHolder)
-					task:=taskholder.FindTask(int64(tid))
-					if task==nil {
+					taskholder := env.TaskHolder.(*fbtask.TaskHolder)
+					task := taskholder.FindTask(int64(tid))
+					if task == nil {
 						env.CommandSender.Output(I18n.T(I18n.TaskNotFoundMessage))
 						return
 					}
-					if(task.Config.Delay().DelayMode==types.DelayModeNone) {
+					if task.Config.Delay().DelayMode == types.DelayModeNone {
 						env.CommandSender.Output(I18n.T(I18n.Task_SetDelay_Unavailable))
 						return
 					}
-					env.CommandSender.Output(fmt.Sprintf(I18n.T(I18n.Task_DelaySet),task.TaskId,del))
-					task.Config.Delay().Delay=int64(del)
+					env.CommandSender.Output(fmt.Sprintf(I18n.T(I18n.Task_DelaySet), task.TaskId, del))
+					task.Config.Delay().Delay = int64(del)
 				},
 			},
-			"setdelaymode": &FunctionChainItem {
-				FunctionType: FunctionTypeSimple,
-				ArgumentTypes: []byte {SimpleFunctionArgumentInt, byte(delayEnumId)},
-				Content: func(env *environment.PBEnvironment,args []interface{}) {
+			"setdelaymode": &FunctionChainItem{
+				FunctionType:  FunctionTypeSimple,
+				ArgumentTypes: []byte{SimpleFunctionArgumentInt, byte(delayEnumId)},
+				Content: func(env *environment.PBEnvironment, args []interface{}) {
 					tid, _ := args[0].(int)
 					delaymode, _ := args[1].(byte)
-					taskholder:=env.TaskHolder.(*fbtask.TaskHolder)
-					task:=taskholder.FindTask(int64(tid))
-					if task==nil {
+					taskholder := env.TaskHolder.(*fbtask.TaskHolder)
+					task := taskholder.FindTask(int64(tid))
+					if task == nil {
 						env.CommandSender.Output(I18n.T(I18n.TaskNotFoundMessage))
 						return
 					}
 					task.Pause()
-					task.Config.Delay().DelayMode=delaymode
-					env.CommandSender.Output(fmt.Sprintf("[%s %d] - %s: %s",I18n.T(I18n.TaskTTeIuKoto),tid,I18n.T(I18n.DelayModeSet),types.StrDelayMode(delaymode)))
-					if delaymode!=types.DelayModeNone {
-						task.Config.Delay().Delay=decideDelay(delaymode)
-						env.CommandSender.Output(fmt.Sprintf("[%s %d] "+I18n.T(I18n.DelayModeSet_DelayAuto),I18n.T(I18n.TaskTTeIuKoto),task.TaskId,task.Config.Delay().Delay))
+					task.Config.Delay().DelayMode = delaymode
+					env.CommandSender.Output(fmt.Sprintf("[%s %d] - %s: %s", I18n.T(I18n.TaskTTeIuKoto), tid, I18n.T(I18n.DelayModeSet), types.StrDelayMode(delaymode)))
+					if delaymode != types.DelayModeNone {
+						task.Config.Delay().Delay = decideDelay(delaymode)
+						env.CommandSender.Output(fmt.Sprintf("[%s %d] "+I18n.T(I18n.DelayModeSet_DelayAuto), I18n.T(I18n.TaskTTeIuKoto), task.TaskId, task.Config.Delay().Delay))
 					}
-					if delaymode==types.DelayModeDiscrete {
-						task.Config.Delay().DelayThreshold=decideDelayThreshold()
-						env.CommandSender.Output(fmt.Sprintf("[%s %d] "+I18n.T(I18n.DelayModeSet_ThresholdAuto),I18n.T(I18n.TaskTTeIuKoto),task.TaskId,task.Config.Delay().DelayThreshold))
+					if delaymode == types.DelayModeDiscrete {
+						task.Config.Delay().DelayThreshold = decideDelayThreshold()
+						env.CommandSender.Output(fmt.Sprintf("[%s %d] "+I18n.T(I18n.DelayModeSet_ThresholdAuto), I18n.T(I18n.TaskTTeIuKoto), task.TaskId, task.Config.Delay().DelayThreshold))
 					}
 					task.Resume()
 				},
 			},
-			"setdelaythreshold": &FunctionChainItem {
-				FunctionType: FunctionTypeSimple,
-				ArgumentTypes: []byte {SimpleFunctionArgumentInt,SimpleFunctionArgumentInt},
-				Content: func(env *environment.PBEnvironment,args []interface{}) {
+			"setdelaythreshold": &FunctionChainItem{
+				FunctionType:  FunctionTypeSimple,
+				ArgumentTypes: []byte{SimpleFunctionArgumentInt, SimpleFunctionArgumentInt},
+				Content: func(env *environment.PBEnvironment, args []interface{}) {
 					tid, _ := args[0].(int)
 					delayt, _ := args[1].(int)
-					taskholder:=env.TaskHolder.(*fbtask.TaskHolder)
-					task:=taskholder.FindTask(int64(tid))
-					if task==nil {
+					taskholder := env.TaskHolder.(*fbtask.TaskHolder)
+					task := taskholder.FindTask(int64(tid))
+					if task == nil {
 						env.CommandSender.Output(I18n.T(I18n.TaskNotFoundMessage))
 						return
 					}
-					if task.Config.Delay().DelayMode!=types.DelayModeDiscrete {
+					if task.Config.Delay().DelayMode != types.DelayModeDiscrete {
 						env.CommandSender.Output(I18n.T(I18n.DelayThreshold_OnlyDiscrete))
 						return
 					}
-					env.CommandSender.Output(fmt.Sprintf("[%s %d] - "+I18n.T(I18n.DelayThreshold_Set),I18n.T(I18n.TaskTTeIuKoto),tid,delayt))
-					task.Config.Delay().DelayThreshold=delayt
+					env.CommandSender.Output(fmt.Sprintf("[%s %d] - "+I18n.T(I18n.DelayThreshold_Set), I18n.T(I18n.TaskTTeIuKoto), tid, delayt))
+					task.Config.Delay().DelayThreshold = delayt
 				},
 			},
 		},
 	})
-	taskTypeEnumId:=fh.RegisterEnum("async, sync",types.ParseTaskType,types.TaskTypeInvalid)
-	fh.RegisterFunction(&Function {
-		Name: "set task type",
-		OwnedKeywords: []string{"tasktype"},
-		FunctionType: FunctionTypeSimple,
-		SFMinSliceLen: 2,
+	taskTypeEnumId := fh.RegisterEnum("async, sync", types.ParseTaskType, types.TaskTypeInvalid)
+	fh.RegisterFunction(&Function{
+		Name:            "set task type",
+		OwnedKeywords:   []string{"tasktype"},
+		FunctionType:    FunctionTypeSimple,
+		SFMinSliceLen:   2,
 		SFArgumentTypes: []byte{byte(taskTypeEnumId)},
-		FunctionContent: func(env *environment.PBEnvironment,args []interface{}) {
-			ev, _:=args[0].(byte)
-			configuration.GlobalFullConfig(env).Global().TaskCreationType=ev
-			env.CommandSender.Output(fmt.Sprintf(I18n.T(I18n.TaskTypeSwitchedTo),types.MakeTaskType(ev)))
+		FunctionContent: func(env *environment.PBEnvironment, args []interface{}) {
+			ev, _ := args[0].(byte)
+			configuration.GlobalFullConfig(env).Global().TaskCreationType = ev
+			env.CommandSender.Output(fmt.Sprintf(I18n.T(I18n.TaskTypeSwitchedTo), types.MakeTaskType(ev)))
 		},
 	})
-	taskDMEnumId:=fh.RegisterEnum("true, false",types.ParseTaskDisplayMode,types.TaskDisplayInvalid)
-	fh.RegisterFunction(&Function {
-		Name: "set progress title display type",
-		OwnedKeywords: []string{"progress"},
-		FunctionType: FunctionTypeSimple,
-		SFMinSliceLen: 2,
+	taskDMEnumId := fh.RegisterEnum("true, false", types.ParseTaskDisplayMode, types.TaskDisplayInvalid)
+	fh.RegisterFunction(&Function{
+		Name:            "set progress title display type",
+		OwnedKeywords:   []string{"progress"},
+		FunctionType:    FunctionTypeSimple,
+		SFMinSliceLen:   2,
 		SFArgumentTypes: []byte{byte(taskDMEnumId)},
-		FunctionContent: func(env *environment.PBEnvironment,args []interface{}) {
-			ev, _:=args[0].(byte)
-			configuration.GlobalFullConfig(env).Global().TaskDisplayMode=ev
-			env.CommandSender.Output(fmt.Sprintf(I18n.T(I18n.TaskDisplayModeSet),types.MakeTaskDisplayMode(ev)))
+		FunctionContent: func(env *environment.PBEnvironment, args []interface{}) {
+			ev, _ := args[0].(byte)
+			configuration.GlobalFullConfig(env).Global().TaskDisplayMode = ev
+			env.CommandSender.Output(fmt.Sprintf(I18n.T(I18n.TaskDisplayModeSet), types.MakeTaskDisplayMode(ev)))
 		},
 	})
 	var builderMethods []string
-	for met,_ := range builder.Builder {
-		builderMethods=append(builderMethods,met)
+	for met, _ := range builder.Builder {
+		builderMethods = append(builderMethods, met)
 	}
-	fh.RegisterFunction(&Function {
-		Name: "ippanbrd",
+	fh.RegisterFunction(&Function{
+		Name:          "ippanbrd",
 		OwnedKeywords: builderMethods,
-		FunctionType:FunctionTypeRegular,
-		FunctionContent: func(env *environment.PBEnvironment,msg string) {
+		FunctionType:  FunctionTypeRegular,
+		FunctionContent: func(env *environment.PBEnvironment, msg string) {
 			task := fbtask.CreateTask(msg, env)
-			if task==nil {
+			if task == nil {
 				return
 			}
-			env.CommandSender.Output(fmt.Sprintf("%s, ID=%d.",I18n.T(I18n.TaskCreated),task.TaskId))
+			env.CommandSender.Output(fmt.Sprintf("%s, ID=%d.", I18n.T(I18n.TaskCreated), task.TaskId))
 		},
 	})
-	fh.RegisterFunction(&Function {
-		Name: "export",
+	fh.RegisterFunction(&Function{
+		Name:          "export",
 		OwnedKeywords: []string{"export"},
-		FunctionType: FunctionTypeRegular,
-		FunctionContent: func(env *environment.PBEnvironment,msg string) {
+		FunctionType:  FunctionTypeRegular,
+		FunctionContent: func(env *environment.PBEnvironment, msg string) {
 			task := special_tasks.CreateExportTask(msg, env)
-			if task==nil {
+			if task == nil {
 				return
 			}
-			env.CommandSender.Output(fmt.Sprintf("%s, ID=%d.",I18n.T(I18n.TaskCreated),task.TaskId))
+			env.CommandSender.Output(fmt.Sprintf("%s, ID=%d.", I18n.T(I18n.TaskCreated), task.TaskId))
 		},
 	})
-	fh.RegisterFunction(&Function {
-		Name: "export(legacy)",
+	fh.RegisterFunction(&Function{
+		Name:          "export(legacy)",
 		OwnedKeywords: []string{"lexport"},
-		FunctionType: FunctionTypeRegular,
-		FunctionContent: func(env *environment.PBEnvironment,msg string) {
+		FunctionType:  FunctionTypeRegular,
+		FunctionContent: func(env *environment.PBEnvironment, msg string) {
 			task := special_tasks.CreateLegacyExportTask(msg, env)
-			if task==nil {
+			if task == nil {
 				return
 			}
-			env.CommandSender.Output(fmt.Sprintf("%s, ID=%d.",I18n.T(I18n.TaskCreated),task.TaskId))
+			env.CommandSender.Output(fmt.Sprintf("%s, ID=%d.", I18n.T(I18n.TaskCreated), task.TaskId))
 		},
 	})
-	fh.RegisterFunction(&Function {
-		Name: "say",
-		OwnedKeywords: []string {"say"},
-		FunctionType:FunctionTypeSimple,
-		SFArgumentTypes: []byte { SimpleFunctionArgumentMessage },
-		SFMinSliceLen: 1,
-		FunctionContent: func(env *environment.PBEnvironment,args []interface{}) {
-			str:=args[0].(string)
+	fh.RegisterFunction(&Function{
+		Name:            "say",
+		OwnedKeywords:   []string{"say"},
+		FunctionType:    FunctionTypeSimple,
+		SFArgumentTypes: []byte{SimpleFunctionArgumentMessage},
+		SFMinSliceLen:   1,
+		FunctionContent: func(env *environment.PBEnvironment, args []interface{}) {
+			str := args[0].(string)
 			env.CommandSender.Output(str)
 		},
 	})
 }
 
-
 func decideDelay(delaytype byte) int64 {
 	// Will add system check later,so don't merge into other functions.
-	if delaytype==types.DelayModeContinuous {
+	if delaytype == types.DelayModeContinuous {
 		return 1000
-	}else if delaytype==types.DelayModeDiscrete {
+	} else if delaytype == types.DelayModeDiscrete {
 		return 15
-	}else{
+	} else {
 		return 0
 	}
 }

--- a/fastbuilder/function/internal.go
+++ b/fastbuilder/function/internal.go
@@ -37,19 +37,20 @@ func InitInternalFunctions(fh *FunctionHolder) {
 		FunctionType:  FunctionTypeSimple,
 		SFMinSliceLen: 1,
 		FunctionContent: func(env *environment.PBEnvironment, _ []interface{}) {
-			fmt.Println(pterm.Green(I18n.T(I18n.Menu_Tip_Cmd_MC_Command)) + " " + pterm.Cyan(I18n.T(I18n.Menu_Tip_MC_Command)))
-			fmt.Println(pterm.Green(I18n.T(I18n.Menu_Tip_Cmd_FB_World_Chat)) + " " + pterm.Cyan(I18n.T(I18n.Menu_Tip_FB_World_Chat)))
-			fmt.Println(pterm.Green(I18n.T(I18n.Menu_Tip_Cmd_Exit)) + " " + pterm.Cyan(I18n.T(I18n.Menu_Tip_Exit)))
-			fmt.Println(pterm.Green(I18n.T(I18n.Menu_Tip_Cmd_Help)) + " " + pterm.Cyan(I18n.T(I18n.Menu_Tip_Help)))
-			fmt.Println(pterm.Green(I18n.T(I18n.Menu_Tip_Cmd_Lang)) + " " + pterm.Cyan(I18n.T(I18n.Menu_Tip_Lang)))
-			fmt.Println(pterm.Green(I18n.T(I18n.Menu_Tip_Cmd_logout)) + " " + pterm.Cyan(I18n.T(I18n.Menu_Tip_logout)))
-			fmt.Println(pterm.Green(I18n.T(I18n.Menu_Tip_Cmd_Progress)) + " " + pterm.Cyan(I18n.T(I18n.Menu_Tip_Progress)))
-			fmt.Println(pterm.Green(I18n.T(I18n.Menu_Tip_Cmd_Round)) + " " + pterm.Cyan(I18n.T(I18n.Menu_Tip_Round)))
-			fmt.Println(pterm.Green(I18n.T(I18n.Menu_Tip_Cmd_Get)) + " " + pterm.Cyan(I18n.T(I18n.Menu_Tip_Get)))
-			fmt.Println(pterm.Green(I18n.T(I18n.Menu_Tip_Cmd_Set)) + " " + pterm.Cyan(I18n.T(I18n.Menu_Tip_Set)))
-			fmt.Println(pterm.Green(I18n.T(I18n.Menu_Tip_Cmd_Task)) + " " + pterm.Cyan(I18n.T(I18n.Menu_Tip_Task)))
-			fmt.Println(pterm.Green(I18n.T(I18n.Menu_Tip_Cmd_Setend)) + " " + pterm.Cyan(I18n.T(I18n.Menu_Tip_Setend)))
-			fmt.Println(pterm.Green(I18n.T(I18n.Menu_Tip_Cmd_delay)) + " " + pterm.Cyan(I18n.T(I18n.Menu_Tip_delay)))
+			fmt.Printf(pterm.Green("%s")+" "+pterm.Cyan("%s\n"), I18n.T(I18n.Menu_Tip_Cmd_MC_Command), I18n.T(I18n.Menu_Tip_MC_Command))
+			fmt.Printf(pterm.Green("%s")+" "+pterm.Cyan("%s\n"), I18n.T(I18n.Menu_Tip_Cmd_FB_World_Chat), I18n.T(I18n.Menu_Tip_FB_World_Chat))
+			fmt.Printf(pterm.Green("%s")+" "+pterm.Cyan("%s\n"), I18n.T(I18n.Menu_Tip_Cmd_Exit), I18n.T(I18n.Menu_Tip_Exit))
+			fmt.Printf(pterm.Green("%s")+" "+pterm.Cyan("%s\n"), I18n.T(I18n.Menu_Tip_Cmd_Help), I18n.T(I18n.Menu_Tip_Help))
+			fmt.Printf(pterm.Green("%s")+" "+pterm.Cyan("%s\n"), I18n.T(I18n.Menu_Tip_Cmd_Lang), I18n.T(I18n.Menu_Tip_Lang))
+			fmt.Printf(pterm.Green("%s")+" "+pterm.Cyan("%s\n"), I18n.T(I18n.Menu_Tip_Cmd_logout), I18n.T(I18n.Menu_Tip_logout))
+			fmt.Printf(pterm.Green("%s")+" "+pterm.Cyan("%s\n"), I18n.T(I18n.Menu_Tip_Cmd_Progress), I18n.T(I18n.Menu_Tip_Progress))
+			fmt.Printf(pterm.Green("%s")+" "+pterm.Cyan("%s\n"), I18n.T(I18n.Menu_Tip_Cmd_Round), I18n.T(I18n.Menu_Tip_Round))
+			fmt.Printf(pterm.Green("%s")+" "+pterm.Cyan("%s\n"), I18n.T(I18n.Menu_Tip_Cmd_Get), I18n.T(I18n.Menu_Tip_Get))
+			fmt.Printf(pterm.Green("%s")+" "+pterm.Cyan("%s\n"), I18n.T(I18n.Menu_Tip_Cmd_Set), I18n.T(I18n.Menu_Tip_Set))
+			fmt.Printf(pterm.Green("%s")+" "+pterm.Cyan("%s\n"), I18n.T(I18n.Menu_Tip_Cmd_Task), I18n.T(I18n.Menu_Tip_Task))
+			fmt.Printf(pterm.Green("%s")+" "+pterm.Cyan("%s\n"), I18n.T(I18n.Menu_Tip_Cmd_Setend), I18n.T(I18n.Menu_Tip_Setend))
+			fmt.Printf(pterm.Green("%s")+" "+pterm.Cyan("%s\n"), I18n.T(I18n.Menu_Tip_Cmd_delay), I18n.T(I18n.Menu_Tip_delay))
+
 		},
 	})
 	fh.RegisterFunction(&Function{

--- a/fastbuilder/function/internal.go
+++ b/fastbuilder/function/internal.go
@@ -32,25 +32,42 @@ func InitInternalFunctions(fh *FunctionHolder) {
 		},
 	})
 	fh.RegisterFunction(&Function{
-		Name:          "help",
-		OwnedKeywords: []string{"help"},
-		FunctionType:  FunctionTypeSimple,
-		SFMinSliceLen: 1,
-		FunctionContent: func(env *environment.PBEnvironment, _ []interface{}) {
-			fmt.Printf(pterm.Green("%s")+" "+pterm.Cyan("%s\n"), I18n.T(I18n.Menu_Tip_Cmd_MC_Command), I18n.T(I18n.Menu_Tip_MC_Command))
-			fmt.Printf(pterm.Green("%s")+" "+pterm.Cyan("%s\n"), I18n.T(I18n.Menu_Tip_Cmd_FB_World_Chat), I18n.T(I18n.Menu_Tip_FB_World_Chat))
-			fmt.Printf(pterm.Green("%s")+" "+pterm.Cyan("%s\n"), I18n.T(I18n.Menu_Tip_Cmd_Exit), I18n.T(I18n.Menu_Tip_Exit))
-			fmt.Printf(pterm.Green("%s")+" "+pterm.Cyan("%s\n"), I18n.T(I18n.Menu_Tip_Cmd_Help), I18n.T(I18n.Menu_Tip_Help))
-			fmt.Printf(pterm.Green("%s")+" "+pterm.Cyan("%s\n"), I18n.T(I18n.Menu_Tip_Cmd_Lang), I18n.T(I18n.Menu_Tip_Lang))
-			fmt.Printf(pterm.Green("%s")+" "+pterm.Cyan("%s\n"), I18n.T(I18n.Menu_Tip_Cmd_logout), I18n.T(I18n.Menu_Tip_logout))
-			fmt.Printf(pterm.Green("%s")+" "+pterm.Cyan("%s\n"), I18n.T(I18n.Menu_Tip_Cmd_Progress), I18n.T(I18n.Menu_Tip_Progress))
-			fmt.Printf(pterm.Green("%s")+" "+pterm.Cyan("%s\n"), I18n.T(I18n.Menu_Tip_Cmd_Round), I18n.T(I18n.Menu_Tip_Round))
-			fmt.Printf(pterm.Green("%s")+" "+pterm.Cyan("%s\n"), I18n.T(I18n.Menu_Tip_Cmd_Get), I18n.T(I18n.Menu_Tip_Get))
-			fmt.Printf(pterm.Green("%s")+" "+pterm.Cyan("%s\n"), I18n.T(I18n.Menu_Tip_Cmd_Set), I18n.T(I18n.Menu_Tip_Set))
-			fmt.Printf(pterm.Green("%s")+" "+pterm.Cyan("%s\n"), I18n.T(I18n.Menu_Tip_Cmd_Task), I18n.T(I18n.Menu_Tip_Task))
-			fmt.Printf(pterm.Green("%s")+" "+pterm.Cyan("%s\n"), I18n.T(I18n.Menu_Tip_Cmd_Setend), I18n.T(I18n.Menu_Tip_Setend))
-			fmt.Printf(pterm.Green("%s")+" "+pterm.Cyan("%s\n"), I18n.T(I18n.Menu_Tip_Cmd_delay), I18n.T(I18n.Menu_Tip_delay))
-
+		Name:            "help",
+		OwnedKeywords:   []string{"help"},
+		FunctionType:    FunctionTypeSimple,
+		SFArgumentTypes: []byte{SimpleFunctionArgumentMessage},
+		SFMinSliceLen:   0,
+		FunctionContent: func(env *environment.PBEnvironment, args []interface{}) {
+			fmt.Println(args) // 临时性调试用,方便查看参数列表
+			if len(args) == 0 || (len(args) == 1 && args[0] == "") || (len(args) == 1 && args[0] == "1") {
+				fmt.Printf(pterm.Green("%s")+" "+pterm.Cyan("%s\n"), I18n.T(I18n.Menu_Tip_Cmd_MC_Command), I18n.T(I18n.Menu_Tip_MC_Command))
+				fmt.Printf(pterm.Green("%s")+" "+pterm.Cyan("%s\n"), I18n.T(I18n.Menu_Tip_Cmd_FB_World_Chat), I18n.T(I18n.Menu_Tip_FB_World_Chat))
+				fmt.Printf(pterm.Green("%s")+" "+pterm.Cyan("%s\n"), I18n.T(I18n.Menu_Tip_Cmd_delay), I18n.T(I18n.Menu_Tip_delay))
+				fmt.Printf(pterm.Green("%s")+" "+pterm.Cyan("%s\n"), I18n.T(I18n.Menu_Tip_Cmd_Exit), I18n.T(I18n.Menu_Tip_Exit))
+				fmt.Printf(pterm.Green("%s")+" "+pterm.Cyan("%s\n"), I18n.T(I18n.Menu_Tip_Cmd_Help), I18n.T(I18n.Menu_Tip_Help))
+				fmt.Printf(pterm.Green("%s")+" "+pterm.Cyan("%s\n"), I18n.T(I18n.Menu_Tip_Cmd_Lang), I18n.T(I18n.Menu_Tip_Lang))
+				fmt.Printf(pterm.Green("%s")+" "+pterm.Cyan("%s\n"), I18n.T(I18n.Menu_Tip_Cmd_logout), I18n.T(I18n.Menu_Tip_logout))
+				fmt.Printf(pterm.Green("%s")+" "+pterm.Cyan("%s\n"), I18n.T(I18n.Menu_Tip_Cmd_Progress), I18n.T(I18n.Menu_Tip_Progress))
+				fmt.Printf(pterm.Green("%s")+" "+pterm.Cyan("%s\n"), I18n.T(I18n.Menu_Tip_Cmd_Round), I18n.T(I18n.Menu_Tip_Round))
+				fmt.Printf(pterm.Green("%s")+" "+pterm.Cyan("%s\n"), I18n.T(I18n.Menu_Tip_Cmd_Get), I18n.T(I18n.Menu_Tip_Get))
+				fmt.Printf(pterm.Green("%s")+" "+pterm.Cyan("%s\n"), I18n.T(I18n.Menu_Tip_Cmd_Set), I18n.T(I18n.Menu_Tip_Set))
+				fmt.Printf(pterm.Green("%s")+" "+pterm.Cyan("%s\n"), I18n.T(I18n.Menu_Tip_Cmd_Task), I18n.T(I18n.Menu_Tip_Task))
+				fmt.Printf(pterm.Green("%s")+" "+pterm.Cyan("%s\n"), I18n.T(I18n.Menu_Tip_Cmd_Setend), I18n.T(I18n.Menu_Tip_Setend))
+			} else if args[0] == "help" {
+				fmt.Printf(I18n.T(I18n.Help_Help))
+			} else if args[0] == "exit" {
+				fmt.Printf(I18n.T(I18n.Help_Exit))
+			} else if args[0] == "delay" {
+				fmt.Printf(I18n.T(I18n.Help_delay))
+			} else if args[0] == "lang" {
+				fmt.Printf(I18n.T(I18n.Help_Lang))
+			} else if args[0] == "logout" {
+				fmt.Printf(I18n.T(I18n.Help_logout))
+			} else if args[0] == "progress" {
+				fmt.Printf(I18n.T(I18n.Help_Progress))
+			} else {
+				fmt.Printf(I18n.T(I18n.Help_No_Find), args[0])
+			}
 		},
 	})
 	fh.RegisterFunction(&Function{

--- a/fastbuilder/i18n/en_US.go
+++ b/fastbuilder/i18n/en_US.go
@@ -137,4 +137,37 @@ var I18nDict_en_US map[uint16]string = map[uint16]string{
 	Task_Summary_3:                      "[Task %d] Average speed: %v blocks/second",
 	UnsupportedACMEVersion:              "Unsupported ACME structure version. Only acme file version 1.2 is supported.",
 	Warning_UserHomeDir:                 "WARNING - Failed to obtain the user's home directory. made homedir=\".\";\n",
+
+	/* 菜单帮助部分的扩展 */
+	// 还没做翻译处理
+
+	Help_Tip_join_1:        "成功进入服务器,您可以在终端输入 ",
+	Help_Tip_join_2:        " 获取帮助",
+	Menu_Tip_MC_Command:    "执行我的世界原生指令,例如:.say 你好,世界",                   // 我的世界 指令在 FB 的执行
+	Menu_Tip_FB_World_Chat: "FB 世界聊天",                                    // FB 世界聊天
+	Menu_Tip_Exit:          "退出FB程序",                                     // FB 退出程序
+	Menu_Tip_Help:          "FB 帮助菜单",                                    // FB 帮助菜单的帮助命令的额外扩展
+	Menu_Tip_Lang:          "切换语言",                                       // FB 语言重新选择
+	Menu_Tip_logout:        "从 FastBuilder 用户中心退出登录",                     // FB 退出登录
+	Menu_Tip_Progress:      "设置是否显示进度条（显示建筑的进度百分比，方块总数，瞬时速度等信息。默认为true）", // FB 是否显示进度条
+	Menu_Tip_Round:         "在指定坐标出为圆点画圆（很多参数,详情请使用 help round查询）",       // FB 画圆命令
+	Menu_Tip_Get:           "获取当前机器人当前坐标并设置为FB导入建筑时的起点",                  // FB 获取当前机器人当前坐标并设置为FB导入建筑时的起点
+	Menu_Tip_Set:           "设置导入建筑的起始点坐标",                               // FB 设置导入建筑的起始点坐标
+	Menu_Tip_Task:          "有关 FB 正在进行的操作列表",                            // FB 任务命令
+	Menu_Tip_Setend:        "设置导入建筑的终点坐标(不是必须设置)",                        // FB 设置导入建筑的终点坐标(不是必须设置)
+	Menu_Tip_delay:         "设置发包方案(指令速度限制)",                             // FB 设置发包方案(指令速度限制)
+
+	Menu_Tip_Cmd_MC_Command:    ".",        // 我的世界 指令在 FB 的执行
+	Menu_Tip_Cmd_FB_World_Chat: ">",        // FB 世界聊天
+	Menu_Tip_Cmd_Exit:          "exit",     // FB 退出程序
+	Menu_Tip_Cmd_Help:          "help",     // FB 帮助菜单的帮助命令的额外扩展
+	Menu_Tip_Cmd_Lang:          "lang",     // FB 语言重新选择
+	Menu_Tip_Cmd_logout:        "exit",     // FB 退出登录
+	Menu_Tip_Cmd_Progress:      "progress", // FB 是否显示进度条
+	Menu_Tip_Cmd_Round:         "Round ",   // FB 画圆命令
+	Menu_Tip_Cmd_Get:           "get",      // FB 获取当前机器人当前坐标并设置为FB导入建筑时的起点
+	Menu_Tip_Cmd_Set:           "set",      // FB 设置导入建筑的起始点坐标
+	Menu_Tip_Cmd_Task:          "task",     // FB 任务命令
+	Menu_Tip_Cmd_Setend:        "setend",   // FB 设置导入建筑的终点坐标(不是必须设置)
+	Menu_Tip_Cmd_delay:         "delay",    // FB 设置发包方案(指令速度限制)
 }

--- a/fastbuilder/i18n/i18n.go
+++ b/fastbuilder/i18n/i18n.go
@@ -199,6 +199,15 @@ const (
 	Menu_Tip_Cmd_Task          // FB 任务命令
 	Menu_Tip_Cmd_Setend        // FB 设置导入建筑的终点坐标(不是必须设置)
 	Menu_Tip_Cmd_delay         // FB 设置发包方案(指令速度限制)
+
+	/* Help 命令的详细描述*/
+	Help_Help
+	Help_Exit
+	Help_delay
+	Help_Lang
+	Help_logout
+	Help_Progress
+	Help_No_Find
 )
 
 var LangDict map[string]map[uint16]string = map[string]map[uint16]string{

--- a/fastbuilder/i18n/i18n.go
+++ b/fastbuilder/i18n/i18n.go
@@ -167,6 +167,38 @@ const (
 	Task_Summary_3
 	UnsupportedACMEVersion
 	Warning_UserHomeDir
+
+	/* 帮助菜单帮助部分的扩展 */
+	Help_Tip_join_1
+	Help_Tip_join_2
+
+	Menu_Tip_MC_Command    // 我的世界 指令在 FB 的执行
+	Menu_Tip_FB_World_Chat // FB 世界聊天
+	Menu_Tip_Exit          // FB 退出程序
+	Menu_Tip_Help          // FB 帮助菜单的帮助命令的额外扩展
+	Menu_Tip_Lang          // FB 语言重新选择
+	Menu_Tip_logout        // FB 退出登录
+	Menu_Tip_Progress      // FB 是否显示进度条
+	Menu_Tip_Round         // FB 画圆命令
+	Menu_Tip_Get           // FB 获取当前机器人当前坐标并设置为FB导入建筑时的起点
+	Menu_Tip_Set           // FB 设置导入建筑的起始点坐标
+	Menu_Tip_Task          // FB 任务命令
+	Menu_Tip_Setend        // FB 设置导入建筑的终点坐标(不是必须设置)
+	Menu_Tip_delay         // FB 设置发包方案(指令速度限制)
+	/* 帮助菜单的语法规则*/
+	Menu_Tip_Cmd_MC_Command    // 我的世界 指令在 FB 的执行
+	Menu_Tip_Cmd_FB_World_Chat // FB 世界聊天
+	Menu_Tip_Cmd_Exit          // FB 退出程序
+	Menu_Tip_Cmd_Help          // FB 帮助菜单的帮助命令的额外扩展
+	Menu_Tip_Cmd_Lang          // FB 语言重新选择
+	Menu_Tip_Cmd_logout        // FB 退出登录
+	Menu_Tip_Cmd_Progress      // FB 是否显示进度条
+	Menu_Tip_Cmd_Round         // FB 画圆命令
+	Menu_Tip_Cmd_Get           // FB 获取当前机器人当前坐标并设置为FB导入建筑时的起点
+	Menu_Tip_Cmd_Set           // FB 设置导入建筑的起始点坐标
+	Menu_Tip_Cmd_Task          // FB 任务命令
+	Menu_Tip_Cmd_Setend        // FB 设置导入建筑的终点坐标(不是必须设置)
+	Menu_Tip_Cmd_delay         // FB 设置发包方案(指令速度限制)
 )
 
 var LangDict map[string]map[uint16]string = map[string]map[uint16]string{

--- a/fastbuilder/i18n/zh_CN.go
+++ b/fastbuilder/i18n/zh_CN.go
@@ -145,4 +145,36 @@ var I18nDict_zh_CN map[uint16]string = map[uint16]string{
 	Task_Summary_3:              "[任务 %d] 平均速度: %v 方块/秒",
 	UnsupportedACMEVersion:      "不支持该版本ACME结构（仅支持acme 1.2文件版本）",
 	Warning_UserHomeDir:         "警告 - 无法获取当前用户主目录，将设定homedir=\".\";\n",
+
+	/* 菜单帮助部分的扩展 */
+
+	Help_Tip_join_1:        "成功进入服务器,您可以在终端输入 ",
+	Help_Tip_join_2:        " 获取帮助",
+	Menu_Tip_MC_Command:    "执行我的世界原生指令,例如:.say 你好,世界",                   // 我的世界 指令在 FB 的执行
+	Menu_Tip_FB_World_Chat: "FB 世界聊天",                                    // FB 世界聊天
+	Menu_Tip_Exit:          "退出FB程序",                                     // FB 退出程序
+	Menu_Tip_Help:          "FB 帮助菜单",                                    // FB 帮助菜单的帮助命令的额外扩展
+	Menu_Tip_Lang:          "切换语言",                                       // FB 语言重新选择
+	Menu_Tip_logout:        "从 FastBuilder 用户中心退出登录",                     // FB 退出登录
+	Menu_Tip_Progress:      "设置是否显示进度条（显示建筑的进度百分比，方块总数，瞬时速度等信息。默认为true）", // FB 是否显示进度条
+	Menu_Tip_Round:         "在指定坐标出为圆点画圆（很多参数,详情请使用 help round查询）",       // FB 画圆命令
+	Menu_Tip_Get:           "获取当前机器人当前坐标并设置为FB导入建筑时的起点",                  // FB 获取当前机器人当前坐标并设置为FB导入建筑时的起点
+	Menu_Tip_Set:           "设置导入建筑的起始点坐标",                               // FB 设置导入建筑的起始点坐标
+	Menu_Tip_Task:          "有关 FB 正在进行的操作列表",                            // FB 任务命令
+	Menu_Tip_Setend:        "设置导入建筑的终点坐标(不是必须设置)",                        // FB 设置导入建筑的终点坐标(不是必须设置)
+	Menu_Tip_delay:         "设置发包方案(指令速度限制)",                             // FB 设置发包方案(指令速度限制)
+
+	Menu_Tip_Cmd_MC_Command:    ".",        // 我的世界 指令在 FB 的执行
+	Menu_Tip_Cmd_FB_World_Chat: ">",        // FB 世界聊天
+	Menu_Tip_Cmd_Exit:          "exit",     // FB 退出程序
+	Menu_Tip_Cmd_Help:          "help",     // FB 帮助菜单的帮助命令的额外扩展
+	Menu_Tip_Cmd_Lang:          "lang",     // FB 语言重新选择
+	Menu_Tip_Cmd_logout:        "exit",     // FB 退出登录
+	Menu_Tip_Cmd_Progress:      "progress", // FB 是否显示进度条
+	Menu_Tip_Cmd_Round:         "Round ",   // FB 画圆命令
+	Menu_Tip_Cmd_Get:           "get",      // FB 获取当前机器人当前坐标并设置为FB导入建筑时的起点
+	Menu_Tip_Cmd_Set:           "set",      // FB 设置导入建筑的起始点坐标
+	Menu_Tip_Cmd_Task:          "task",     // FB 任务命令
+	Menu_Tip_Cmd_Setend:        "setend",   // FB 设置导入建筑的终点坐标(不是必须设置)
+	Menu_Tip_Cmd_delay:         "delay",    // FB 设置发包方案(指令速度限制)
 }

--- a/fastbuilder/i18n/zh_CN.go
+++ b/fastbuilder/i18n/zh_CN.go
@@ -177,4 +177,14 @@ var I18nDict_zh_CN map[uint16]string = map[uint16]string{
 	Menu_Tip_Cmd_Task:          "task",     // FB 任务命令
 	Menu_Tip_Cmd_Setend:        "setend",   // FB 设置导入建筑的终点坐标(不是必须设置)
 	Menu_Tip_Cmd_delay:         "delay",    // FB 设置发包方案(指令速度限制)
+
+	/*Help 部分的详细描述*/
+	Help_No_Find: "未找到对应的 %s 帮助命令\n",
+
+	Help_Help:     "help <页码:int> 打开帮助菜单的对应页码(当前版本仅支持第一页)\nhelp <命令:str> 详细描述对应命令的语法以及帮助,说明\n",
+	Help_Exit:     "exit 退出应用程序(不需要任何参数) \n例:exit\n正常退出\n",
+	Help_delay:    "delay 设置全局指令执行延迟和执行方案：\ndelay mode <delayMode:continuous|discrete|none>  设定默认的发包方案\ndelay threshold <threshold:int>  设定默认阈值（最大方块集合），仅在 discrete 方案下有效\ndelay set <Delay>  设定默认的发包延迟。在continuous模式下单位为微秒； 在discrete模式下单位为秒\n",
+	Help_Lang:     "lang 切换语言\n例:请在控制台中选择新语言\n[1] English\n[2] English (UK)\n[3] 简体中文\n[4] 繁體中文（香港）\n[5] 繁體中文（台灣）\n(ID): 3\n语言偏好已更新\n(注意:此示范是在简体中文的情况下执行的命令)\n",
+	Help_logout:   "logout 退出登录,在执行完成此命令后将会退出FB并且下次登录需要重新输入用户名和密码\n例:logout\n已从FastBuilder用户中心退出登录。\n正常退出\n",
+	Help_Progress: "progress <value:bool> 设置是否显示进度条（显示建筑的进度百分比，方块总数，瞬时速度等信息。默认为true）\n例:progress True\n解析器：无效枚举值，可用值有：true, false.\nprogress true\n任务状态显示模式已经设置为: true.\nprogress false\n任务状态显示模式已经设置为: false.\n",
 }


### PR DESCRIPTION
在 FB的终端 增加一个 help 命令
以方便用户在终端查询命令,
help 命令 的格式 遵循 Linux 的help命令

此次提交提供了部分简体中文以及 单 help 命令时的 终端处理