### PR TITLE
Fix library loading errors on BSD systems

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -362,8 +362,12 @@ report_error() {
 }
 
 # Download a file contains the latest version num for FastBuilder distros
-printf "Getting latest version of FastBuilder..."
-${DL_TOOL} ${DL_TOOL_OUT_FLAG} "${PREFIX}"/./fastbuilder-temp/version ${FB_DOMAIN}${FB_LOCATION_ROOT}/version
+printf "Getting latest version of FastBuilder...\n"
+FB_VERSION_LINK="${FB_DOMAIN}${FB_LOCATION_ROOT}/version"
+if [[ ${PB_USE_GH_REPO} == "1" ]]; then
+  FB_VERSION_LINK="${GH_DOMAIN}/${GH_USER}/${GH_REPO}/raw/main/version"
+fi
+${DL_TOOL} ${DL_TOOL_OUT_FLAG} "${PREFIX}"/./fastbuilder-temp/version $FB_VERSION_LINK
 DL_RET=$?
 if [ ${DL_RET} == 0 ]; then
   FB_VER=$(cat "${PREFIX}"/./fastbuilder-temp/version | sed -n -e 'H;${x;s/\n//g;p;}')


### PR DESCRIPTION
Cause of error: 
The library that fastbuilder needs to use has a different name from the existing library file in the system.

Repair method:
`find / -name *libz.so*`
`ln -s {path_to_libz.so} /usr/lib/libz.so.1`

I don't know if this fix is optimal, would appreciate advice.

Test on OpenBSD 7.2:
![image](https://user-images.githubusercontent.com/63277109/202229261-a71b1c51-7faa-4d7c-8c79-20ae77191d1a.png)

Test on FreeBSD 13.1:
![image](https://user-images.githubusercontent.com/63277109/202229585-ce42d9a5-2ea9-4377-acf1-5d31fe457c3e.png)
