### PR TITLE
群服互通错误修复

### DIFF
--- a/omega/components/qqGroupLink/cq-http.go
+++ b/omega/components/qqGroupLink/cq-http.go
@@ -108,6 +108,9 @@ func (cq *QGroupLink) receiveRoutine() {
 		}
 		// 接收到群名片更新数据包时, Echo为自定义的返回字段
 		if post.Echo == "GetGroupCards" {
+			if post.Data == nil {
+				continue
+			}
 			for _, v := range post.Data.([]interface{}) {
 				mem := GroupMemberInfo{}
 				if bytes, err := json.Marshal(v); err == nil {


### PR DESCRIPTION
群服互通问题修复：当`go-cqhttp`返回的群名片数据为`nil`时，会导致程序崩溃的问题