### PR TITLE
Fix an issue where imports can not be performed for the Nether and the End dimension

### DIFF
--- a/fastbuilder/commands_generator/replaceitem.go
+++ b/fastbuilder/commands_generator/replaceitem.go
@@ -6,5 +6,5 @@ import (
 )
 
 func ReplaceItemRequest(module *types.Module, config *types.MainConfig, BotName string) string {
-	return fmt.Sprintf("execute @a[name=%v] ~ ~ ~ replaceitem block %d %d %d slot.container %d %s %d %d", BotName, module.Point.X, module.Point.Y, module.Point.Z, module.ChestSlot.Slot, module.ChestSlot.Name, module.ChestSlot.Count, module.ChestSlot.Damage)
+	return fmt.Sprintf("execute @a[name=\"%v\"] ~ ~ ~ replaceitem block %d %d %d slot.container %d %s %d %d", BotName, module.Point.X, module.Point.Y, module.Point.Z, module.ChestSlot.Slot, module.ChestSlot.Name, module.ChestSlot.Count, module.ChestSlot.Damage)
 }

--- a/fastbuilder/commands_generator/replaceitem.go
+++ b/fastbuilder/commands_generator/replaceitem.go
@@ -5,7 +5,6 @@ import (
 	"phoenixbuilder/fastbuilder/types"
 )
 
-
-func ReplaceItemRequest(module *types.Module, config *types.MainConfig) string {
-	return fmt.Sprintf("replaceitem block %d %d %d slot.container %d %s %d %d", module.Point.X, module.Point.Y, module.Point.Z, module.ChestSlot.Slot, module.ChestSlot.Name, module.ChestSlot.Count, module.ChestSlot.Damage)
+func ReplaceItemRequest(module *types.Module, config *types.MainConfig, BotName string) string {
+	return fmt.Sprintf("execute @a[name=%v] ~ ~ ~ replaceitem block %d %d %d slot.container %d %s %d %d", BotName, module.Point.X, module.Point.Y, module.Point.Z, module.ChestSlot.Slot, module.ChestSlot.Name, module.ChestSlot.Count, module.ChestSlot.Damage)
 }

--- a/fastbuilder/commands_generator/setblock.go
+++ b/fastbuilder/commands_generator/setblock.go
@@ -9,6 +9,9 @@ func SetBlockRequest(module *types.Module, config *types.MainConfig, BotName str
 	Block := module.Block
 	Point := module.Point
 	Method := config.Method
+	if Method == "replace" {
+		Method = ""
+	}
 	if Block != nil {
 		if len(Block.BlockStates) != 0 {
 			return fmt.Sprintf("execute @a[name=\"%v\"] ~ ~ ~ setblock %d %d %d %s %s %s", BotName, Point.X, Point.Y, Point.Z, *Block.Name, Block.BlockStates, Method)

--- a/fastbuilder/commands_generator/setblock.go
+++ b/fastbuilder/commands_generator/setblock.go
@@ -5,19 +5,18 @@ import (
 	"phoenixbuilder/fastbuilder/types"
 )
 
-func SetBlockRequest(module *types.Module, config *types.MainConfig) string {
+func SetBlockRequest(module *types.Module, config *types.MainConfig, BotName string) string {
 	Block := module.Block
 	Point := module.Point
 	Method := config.Method
 	if Block != nil {
-		if len(Block.BlockStates)!=0 {
-			return fmt.Sprintf("setblock %d %d %d %s %s %s", Point.X, Point.Y, Point.Z, *Block.Name, Block.BlockStates, Method)
-		}else{
-			return fmt.Sprintf("setblock %d %d %d %s %d %s", Point.X, Point.Y, Point.Z, *Block.Name, Block.Data, Method)
+		if len(Block.BlockStates) != 0 {
+			return fmt.Sprintf("execute @a[name=%v] ~ ~ ~ setblock %d %d %d %s %s %s", BotName, Point.X, Point.Y, Point.Z, *Block.Name, Block.BlockStates, Method)
+		} else {
+			return fmt.Sprintf("execute @a[name=%v] ~ ~ ~ setblock %d %d %d %s %d %s", BotName, Point.X, Point.Y, Point.Z, *Block.Name, Block.Data, Method)
 		}
 	} else {
-		return fmt.Sprintf("setblock %d %d %d %s %d %s", Point.X, Point.Y, Point.Z, config.Block.Name, config.Block.Data, Method)
+		return fmt.Sprintf("execute @a[name=%v] ~ ~ ~ setblock %d %d %d %s %d %s", BotName, Point.X, Point.Y, Point.Z, config.Block.Name, config.Block.Data, Method)
 	}
-	
-}
 
+}

--- a/fastbuilder/commands_generator/setblock.go
+++ b/fastbuilder/commands_generator/setblock.go
@@ -11,12 +11,12 @@ func SetBlockRequest(module *types.Module, config *types.MainConfig, BotName str
 	Method := config.Method
 	if Block != nil {
 		if len(Block.BlockStates) != 0 {
-			return fmt.Sprintf("execute @a[name=%v] ~ ~ ~ setblock %d %d %d %s %s %s", BotName, Point.X, Point.Y, Point.Z, *Block.Name, Block.BlockStates, Method)
+			return fmt.Sprintf("execute @a[name=\"%v\"] ~ ~ ~ setblock %d %d %d %s %s %s", BotName, Point.X, Point.Y, Point.Z, *Block.Name, Block.BlockStates, Method)
 		} else {
-			return fmt.Sprintf("execute @a[name=%v] ~ ~ ~ setblock %d %d %d %s %d %s", BotName, Point.X, Point.Y, Point.Z, *Block.Name, Block.Data, Method)
+			return fmt.Sprintf("execute @a[name=\"%v\"] ~ ~ ~ setblock %d %d %d %s %d %s", BotName, Point.X, Point.Y, Point.Z, *Block.Name, Block.Data, Method)
 		}
 	} else {
-		return fmt.Sprintf("execute @a[name=%v] ~ ~ ~ setblock %d %d %d %s %d %s", BotName, Point.X, Point.Y, Point.Z, config.Block.Name, config.Block.Data, Method)
+		return fmt.Sprintf("execute @a[name=\"%v\"] ~ ~ ~ setblock %d %d %d %s %d %s", BotName, Point.X, Point.Y, Point.Z, config.Block.Name, config.Block.Data, Method)
 	}
 
 }

--- a/fastbuilder/commands_generator/summon.go
+++ b/fastbuilder/commands_generator/summon.go
@@ -13,8 +13,8 @@ func SummonRequest(module *types.Module, config *types.MainConfig, BotName strin
 	Point := module.Point
 	Method := config.Method
 	if Entity != nil {
-		return fmt.Sprintf("execute @a[name=%v] ~ ~ ~ summon %s %v %v %v", BotName, *Entity, Point.X, Point.Y, Point.Z)
+		return fmt.Sprintf("execute @a[name=\"%v\"] ~ ~ ~ summon %s %v %v %v", BotName, *Entity, Point.X, Point.Y, Point.Z)
 	} else {
-		return fmt.Sprintf("execute @a[name=%v] ~ ~ ~ summon %s %v %v %v", BotName, *Entity, Point.X, Point.Y, Point.Z)
+		return fmt.Sprintf("execute @a[name=\"%v\"] ~ ~ ~ summon %s %v %v %v", BotName, *Entity, Point.X, Point.Y, Point.Z)
 	}
 }

--- a/fastbuilder/commands_generator/summon.go
+++ b/fastbuilder/commands_generator/summon.go
@@ -1,3 +1,4 @@
+//go:build do_not_add_this_tag__not_implemented
 // +build do_not_add_this_tag__not_implemented
 
 package commands_generator
@@ -7,15 +8,13 @@ import (
 	"phoenixbuilder/fastbuilder/types"
 )
 
-
-func SummonRequest(module *types.Module, config *types.MainConfig) string {
+func SummonRequest(module *types.Module, config *types.MainConfig, BotName string) string {
 	Entity := module.Entity
 	Point := module.Point
 	Method := config.Method
 	if Entity != nil {
-		return fmt.Sprintf("summon %s %v %v %v", *Entity, Point.X, Point.Y, Point.Z)
+		return fmt.Sprintf("execute @a[name=%v] ~ ~ ~ summon %s %v %v %v", BotName, *Entity, Point.X, Point.Y, Point.Z)
 	} else {
-		return fmt.Sprintf("summon %s %v %v %v", *Entity, Point.X, Point.Y, Point.Z)
+		return fmt.Sprintf("execute @a[name=%v] ~ ~ ~ summon %s %v %v %v", BotName, *Entity, Point.X, Point.Y, Point.Z)
 	}
 }
-

--- a/fastbuilder/environment/interfaces/command_sender.go
+++ b/fastbuilder/environment/interfaces/command_sender.go
@@ -1,18 +1,20 @@
 package interfaces
 
 import (
-	"github.com/google/uuid"
 	"sync"
+
+	"github.com/google/uuid"
 )
 
 type CommandSender interface {
 	GetUUIDMap() *sync.Map
 	ClearUUIDMap()
 	GetBlockUpdateSubscribeMap() *sync.Map
-	SendCommand(string,uuid.UUID) error
-	SendWSCommand(string,uuid.UUID) error
+	SendCommand(string, uuid.UUID) error
+	SendWSCommand(string, uuid.UUID) error
 	SendSizukanaCommand(string) error
 	SendChat(string) error
+	GetBotName() string
 	Output(string) error
 	WorldChatOutput(string, string) error
 	Title(string) error

--- a/fastbuilder/task/task.go
+++ b/fastbuilder/task/task.go
@@ -256,7 +256,10 @@ func CreateTask(commandLine string, env *environment.PBEnvironment) *Task {
 			cmdsender.SendWSCommand("gamemode c", und)
 			cmdsender.SendWSCommand("gamerule sendcommandfeedback true", und)
 		}
+
 		BotName := cmdsender.GetBotName()
+		// 获取机器人的名字，用于 setblock 时利用 execute 命令更变命令执行维度
+
 		for {
 			task.ContinueLock.Lock()
 			task.ContinueLock.Unlock()
@@ -278,7 +281,7 @@ func CreateTask(commandLine string, env *environment.PBEnvironment) *Task {
 			}
 			if blkscounter%20 == 0 {
 				u_d, _ := uuid.NewUUID()
-				cmdsender.SendWSCommand(fmt.Sprintf("execute @a[name=%v] ~ ~ ~ tp %d %d %d", BotName, curblock.Point.X, curblock.Point.Y, curblock.Point.Z), u_d)
+				cmdsender.SendWSCommand(fmt.Sprintf("execute @a[name=\"%v\"] ~ ~ ~ tp %d %d %d", BotName, curblock.Point.X, curblock.Point.Y, curblock.Point.Z), u_d)
 				// SettingsCommand is unable to teleport the player.
 			}
 			blkscounter++
@@ -309,7 +312,7 @@ func CreateTask(commandLine string, env *environment.PBEnvironment) *Task {
 					UUID := uuid.New()
 					w := make(chan *packet.CommandOutput)
 					(*cmdsender.GetUUIDMap()).Store(UUID.String(), w)
-					cmdsender.SendWSCommand(fmt.Sprintf("execute @a[name=%v] ~ ~ ~ tp %d %d %d", BotName, curblock.Point.X, curblock.Point.Y+1, curblock.Point.Z), UUID)
+					cmdsender.SendWSCommand(fmt.Sprintf("execute @a[name=\"%v\"] ~ ~ ~ tp %d %d %d", BotName, curblock.Point.X, curblock.Point.Y+1, curblock.Point.Z), UUID)
 					select {
 					case <-time.After(time.Second):
 						(*cmdsender.GetUUIDMap()).Delete(UUID.String())

--- a/io/commands/sender.go
+++ b/io/commands/sender.go
@@ -84,11 +84,12 @@ func (sender *CommandSender) SendChat(content string) error {
 	})
 }
 
+// 获取机器人的名字，用于 setblock 时利用 execute 命令更变命令执行维度
 func (sender *CommandSender) GetBotName() string {
 	ud, _ := uuid.NewUUID()
 	chann := make(chan *packet.CommandOutput)
 	sender.UUIDMap.Store(ud.String(), chann)
-	sender.SendCommand("testfor @s", ud)
+	sender.SendWSCommand("testfor @s", ud)
 	resp := <-chann
 	return resp.OutputMessages[0].Parameters[0]
 }

--- a/io/commands/sender.go
+++ b/io/commands/sender.go
@@ -1,14 +1,16 @@
+//go:build !is_tweak
 // +build !is_tweak
 
 package commands
 
 import (
+	"fmt"
 	"phoenixbuilder/minecraft"
 	"phoenixbuilder/minecraft/protocol"
 	"phoenixbuilder/minecraft/protocol/packet"
-	"github.com/google/uuid"
 	"sync"
-	"fmt"
+
+	"github.com/google/uuid"
 )
 
 func (sender *CommandSender) GetBlockUpdateSubscribeMap() *sync.Map {
@@ -20,11 +22,11 @@ func (sender *CommandSender) GetUUIDMap() *sync.Map {
 }
 
 func (sender *CommandSender) ClearUUIDMap() {
-	sender.UUIDMap=sync.Map{}
+	sender.UUIDMap = sync.Map{}
 }
 
 func (sender *CommandSender) getConn() *minecraft.Conn {
-	conn:=sender.env.Connection.(*minecraft.Conn)
+	conn := sender.env.Connection.(*minecraft.Conn)
 	return conn
 }
 
@@ -64,20 +66,29 @@ func (sender *CommandSender) SendWSCommand(command string, UUID uuid.UUID) error
 
 func (sender *CommandSender) SendSizukanaCommand(command string) error {
 	return sender.getConn().WritePacket(&packet.SettingsCommand{
-		CommandLine: command,
+		CommandLine:    command,
 		SuppressOutput: true,
 	})
 }
 
 func (sender *CommandSender) SendChat(content string) error {
-	conn:=sender.getConn()
-	idd:=conn.IdentityData()
-	return conn.WritePacket(&packet.Text {
-		TextType: packet.TextTypeChat,
+	conn := sender.getConn()
+	idd := conn.IdentityData()
+	return conn.WritePacket(&packet.Text{
+		TextType:         packet.TextTypeChat,
 		NeedsTranslation: false,
-		SourceName: idd.DisplayName,
-		Message: content,
-		XUID: idd.XUID,
-		PlayerRuntimeID: fmt.Sprintf("%d",conn.GameData().EntityUniqueID),
+		SourceName:       idd.DisplayName,
+		Message:          content,
+		XUID:             idd.XUID,
+		PlayerRuntimeID:  fmt.Sprintf("%d", conn.GameData().EntityUniqueID),
 	})
+}
+
+func (sender *CommandSender) GetBotName() string {
+	ud, _ := uuid.NewUUID()
+	chann := make(chan *packet.CommandOutput)
+	sender.UUIDMap.Store(ud.String(), chann)
+	sender.SendCommand("testfor @s", ud)
+	resp := <-chann
+	return resp.OutputMessages[0].Parameters[0]
 }

--- a/omega/defines/organization.go
+++ b/omega/defines/organization.go
@@ -148,7 +148,7 @@ type GameControl interface {
 	SetOnParamMsg(string, func(chat *GameChat) (catch bool)) error
 	PlaceCommandBlock(pos define.CubePos, commandBlockName string, commandBlockData int,
 		withMove, withAirPrePlace bool, updatePacket *packet.CommandBlockUpdate,
-		onDone func(done bool), timeOut time.Duration)
+		onDone func(done bool), timeOut time.Duration, BotName string)
 }
 
 type PlayerKit interface {

--- a/omega/mainframe/game_ctrl.go
+++ b/omega/mainframe/game_ctrl.go
@@ -540,7 +540,7 @@ func (g *GameCtrl) onBlockActor(p *packet.BlockActorData) {
 
 func (g *GameCtrl) PlaceCommandBlock(pos define.CubePos, commandBlockName string, commandBlockData int,
 	withMove, withAirPrePlace bool, updatePacket *packet.CommandBlockUpdate,
-	onDone func(done bool), timeOut time.Duration) {
+	onDone func(done bool), timeOut time.Duration, BotName string) {
 	done := make(chan bool)
 	go func() {
 		select {
@@ -551,20 +551,20 @@ func (g *GameCtrl) PlaceCommandBlock(pos define.CubePos, commandBlockName string
 	}()
 	go func() {
 		if withMove {
-			g.SendCmd(fmt.Sprintf("tp @s %v %v %v", pos.X(), pos.Y(), pos.Z()))
+			g.SendCmd(fmt.Sprintf("execute @a[name=\"%v\"] ~ ~ ~ tp @s %v %v %v", BotName, pos.X(), pos.Y(), pos.Z()))
 			time.Sleep(100 * time.Millisecond)
 		}
 		if withAirPrePlace {
-			cmd := fmt.Sprintf("setblock %v %v %v %v %v", pos[0], pos[1], pos[2], "air", 0)
+			cmd := fmt.Sprintf("execute @a[name=\"%v\"] ~ ~ ~ setblock %v %v %v %v %v", BotName, pos[0], pos[1], pos[2], "air", 0)
 			g.SendWOCmd(cmd)
 			time.Sleep(100 * time.Millisecond)
 		}
-		cmd := fmt.Sprintf("setblock %v %v %v %v %v", pos[0], pos[1], pos[2], strings.Replace(commandBlockName, "minecraft:", "", 1), commandBlockData)
+		cmd := fmt.Sprintf("execute @a[name=\"%v\"] ~ ~ ~ setblock %v %v %v %v %v", BotName, pos[0], pos[1], pos[2], strings.Replace(commandBlockName, "minecraft:", "", 1), commandBlockData)
 		g.SendWOCmd(cmd)
 		g.onBlockActorCbs[pos] = func(cp define.CubePos, bad *packet.BlockActorData) {
 			go func() {
 				g.placeCommandBlockLock.Lock()
-				g.SendCmd(fmt.Sprintf("tp @s %v %v %v", pos.X(), pos.Y(), pos.Z()))
+				g.SendCmd(fmt.Sprintf("execute @a[name=\"%v\"] ~ ~ ~ tp @s %v %v %v", BotName, pos.X(), pos.Y(), pos.Z()))
 				time.Sleep(50 * time.Millisecond)
 				g.SendMCPacket(updatePacket)
 				g.placeCommandBlockLock.Unlock()

--- a/omega/utils/structure/builder.go
+++ b/omega/utils/structure/builder.go
@@ -178,7 +178,7 @@ func (o *Builder) Build(blocksIn chan *IOBlockForBuilder, speed int, boostSleepT
 							if !done {
 								pterm.Error.Printfln("命令方块放置失败: 坐标: %v 名称: %v %v 信息: %v", block.Pos, blk.Name, blk.Val, block.NBT)
 							}
-						}, time.Second*3)
+						}, time.Second*3, BotName)
 					}
 					fallBackActionsMu.Unlock()
 					o.Ctrl.PlaceCommandBlock(block.Pos, blk.Name, int(blk.Val), false, true, cfg, func(done bool) {
@@ -189,7 +189,7 @@ func (o *Builder) Build(blocksIn chan *IOBlockForBuilder, speed int, boostSleepT
 							delete(fallBackActions, block.Pos)
 							fallBackActionsMu.Unlock()
 						}
-					}, time.Second*3)
+					}, time.Second*3, BotName)
 					for time.Since(placeStart) < time.Millisecond*50 {
 						if !quickDone {
 							time.Sleep(time.Millisecond)

--- a/omega/utils/structure/builder.go
+++ b/omega/utils/structure/builder.go
@@ -98,12 +98,12 @@ func (o *Builder) Build(blocksIn chan *IOBlockForBuilder, speed int, boostSleepT
 		xmove := block.Pos.X() - lastPos.X()
 		zmove := block.Pos.Z() - lastPos.Z()
 		if counter == 0 {
-			o.NormalCmdSender(fmt.Sprintf("execute @a[name=%v] ~ ~ ~ tp @s %v %v %v", BotName, block.Pos[0], 320, block.Pos[2]))
+			o.NormalCmdSender(fmt.Sprintf("execute @a[name=\"%v\"] ~ ~ ~ tp @s %v %v %v", BotName, block.Pos[0], 320, block.Pos[2]))
 			lastPos = block.Pos
 			time.Sleep(3 * time.Second)
 		}
 		if (xmove*xmove) > 16*16 || (zmove*zmove) > 16*16 {
-			o.NormalCmdSender(fmt.Sprintf("execute @a[name=%v] ~ ~ ~ tp @s %v %v %v", BotName, block.Pos[0], 320, block.Pos[2]))
+			o.NormalCmdSender(fmt.Sprintf("execute @a[name=\"%v\"] ~ ~ ~ tp @s %v %v %v", BotName, block.Pos[0], 320, block.Pos[2]))
 			lastPos = block.Pos
 			<-moveTicker.C
 
@@ -156,7 +156,7 @@ func (o *Builder) Build(blocksIn chan *IOBlockForBuilder, speed int, boostSleepT
 		}
 		o.ProgressUpdater(counter)
 		if block.Expand16 {
-			cmd := fmt.Sprintf("execute @a[name=%v] ~ ~ ~ fill %v %v %v %v %v %v %v %v", BotName, block.Pos[0], block.Pos[1], block.Pos[2], block.Pos[0]+15, block.Pos[1]+15, block.Pos[2]+15, strings.Replace(blk.Name, "minecraft:", "", 1), blk.Val)
+			cmd := fmt.Sprintf("execute @a[name=\"%v\"] ~ ~ ~ fill %v %v %v %v %v %v %v %v", BotName, block.Pos[0], block.Pos[1], block.Pos[2], block.Pos[0]+15, block.Pos[1]+15, block.Pos[2]+15, strings.Replace(blk.Name, "minecraft:", "", 1), blk.Val)
 			// fmt.Println("fast fill")
 			o.NormalCmdSender(cmd)
 			counter += 4096
@@ -204,15 +204,15 @@ func (o *Builder) Build(blocksIn chan *IOBlockForBuilder, speed int, boostSleepT
 			} else {
 				// fmt.Println(block.BlockName, block.BlockStates, block.BlockData, "test")
 				if block.BlockName != "" && block.BlockStates != "" {
-					cmd := fmt.Sprintf("execute @a[name=%v] ~ ~ ~ setblock %v %v %v %v %v", BotName, block.Pos[0], block.Pos[1], block.Pos[2], strings.Replace(block.BlockName, "minecraft:", "", 1), block.BlockStates)
+					cmd := fmt.Sprintf("execute @a[name=\"%v\"] ~ ~ ~ setblock %v %v %v %v %v", BotName, block.Pos[0], block.Pos[1], block.Pos[2], strings.Replace(block.BlockName, "minecraft:", "", 1), block.BlockStates)
 					o.BlockCmdSender(cmd)
 					// fmt.Println(cmd)
 				} else if block.BlockName != "" && block.BlockStates == "" {
-					cmd := fmt.Sprintf("execute @a[name=%v] ~ ~ ~ setblock %v %v %v %v %v", BotName, block.Pos[0], block.Pos[1], block.Pos[2], strings.Replace(block.BlockName, "minecraft:", "", 1), block.BlockData)
+					cmd := fmt.Sprintf("execute @a[name=\"%v\"] ~ ~ ~ setblock %v %v %v %v %v", BotName, block.Pos[0], block.Pos[1], block.Pos[2], strings.Replace(block.BlockName, "minecraft:", "", 1), block.BlockData)
 					o.BlockCmdSender(cmd)
 					// fmt.Println(cmd)
 				} else {
-					cmd := fmt.Sprintf("execute @a[name=%v] ~ ~ ~ setblock %v %v %v %v %v", BotName, block.Pos[0], block.Pos[1], block.Pos[2], strings.Replace(blk.Name, "minecraft:", "", 1), blk.Val)
+					cmd := fmt.Sprintf("execute @a[name=\"%v\"] ~ ~ ~ setblock %v %v %v %v %v", BotName, block.Pos[0], block.Pos[1], block.Pos[2], strings.Replace(blk.Name, "minecraft:", "", 1), blk.Val)
 					o.BlockCmdSender(cmd)
 					// fmt.Println(cmd)
 				}


### PR DESCRIPTION
# 更改
 - 对于 `bdump` 部分，关于 `setblock_request, replaceitem_request, summon_request` 部分，现在通过使用 `execute @e[name=<BOTNAME>] ~ ~ ~ <command>` 的格式来解决默认执行维度在 `Overworld(主世界)` 的问题
- 同上理，`omega` 的 `统一导入系统` 也有相似的更改
- 同上理，因导入时产生的 `tp` 也会更变 `命令执行维度` 了