### PR TITLE
Rewrite the code for `Legacy Export`

### DIFF
--- a/fastbuilder/bdump/bdump_legacy.go
+++ b/fastbuilder/bdump/bdump_legacy.go
@@ -1,18 +1,42 @@
 package bdump
 
 import (
-	"github.com/andybalholm/brotli"
-	"phoenixbuilder/fastbuilder/types"
 	"bytes"
+	"encoding/binary"
 	"fmt"
 	"os"
-	"encoding/binary"
 	"phoenixbuilder/fastbuilder/bdump/command"
+	"phoenixbuilder/fastbuilder/types"
+
+	"github.com/andybalholm/brotli"
 )
 
 type BDumpLegacy struct {
 	Author string // Should be empty
 	Blocks []*types.Module
+}
+
+// containerIndex {blockName: {blockData: RunTimeIdIn117}}
+var containerIndex map[string]map[int]int = map[string]map[int]int{
+	"blast_furnace":      {0: 659, 1: 660, 2: 661, 3: 662, 4: 663, 5: 664},
+	"lit_blast_furnace":  {0: 5413, 1: 5414, 2: 5415, 3: 5416, 4: 5417, 5: 5418},
+	"smoker":             {0: 6636, 1: 6637, 2: 6638, 3: 6639, 4: 6640, 5: 6641},
+	"lit_smoker":         {0: 5432, 1: 5433, 2: 5434, 3: 5435, 4: 5436, 5: 5437},
+	"furnace":            {0: 4813, 1: 4814, 2: 4815, 3: 4816, 4: 4817, 5: 4818},
+	"lit_furnace":        {0: 5420, 1: 5421, 2: 5422, 3: 5423, 4: 5424, 5: 5425},
+	"chest":              {0: 1083, 1: 1084, 2: 1085, 3: 1086, 4: 1087, 5: 1088},
+	"barrel":             {0: 201, 1: 202, 2: 203, 3: 204, 4: 205, 5: 206, 11: 210, 12: 211, 13: 212},
+	"trapped_chest":      {0: 7135, 1: 7136, 2: 7137, 3: 7138, 4: 7139, 5: 7140},
+	"lectern":            {0: 5339, 1: 5340, 2: 5341, 3: 5342, 4: 5343, 5: 5344, 6: 5345, 7: 5346},
+	"hopper":             {0: 5019, 1: 5020, 2: 5021, 3: 5022, 4: 5023, 5: 5024, 8: 5025, 9: 5026, 10: 5027, 11: 5028, 12: 5029, 13: 5030},
+	"dispenser":          {0: 4436, 1: 4437, 2: 4438, 3: 4439, 4: 4440, 5: 4441, 8: 4442, 9: 4443, 10: 4444, 11: 4445, 12: 4446, 13: 4447},
+	"dropper":            {0: 4535, 1: 4536, 2: 4537, 3: 4538, 4: 4539, 5: 4540, 8: 4541, 9: 4542, 10: 4543, 11: 4544, 12: 4545, 13: 4546},
+	"cauldron":           {0: 952, 1: 953, 2: 954, 3: 955, 4: 956, 5: 957, 6: 958, 8: 959, 9: 960, 10: 961, 11: 962, 12: 963, 13: 964, 14: 965, 16: 966, 17: 967, 18: 968, 19: 969, 20: 970, 21: 971, 22: 972},
+	"lava_cauldron":      {0: 5294, 1: 5295, 2: 5296, 3: 5297, 4: 5298, 5: 5299, 6: 5300, 8: 5301, 9: 5302, 10: 5303, 11: 5304, 12: 5305, 13: 5306, 14: 5307, 16: 5308, 17: 5309, 18: 5310, 19: 5311, 20: 5312, 21: 5313, 22: 5314},
+	"jukebox":            {0: 5113},
+	"brewing_stand":      {0: 847, 1: 848, 2: 849, 3: 850, 4: 851, 5: 852, 6: 853, 7: 854},
+	"undyed_shulker_box": {0: 7218},
+	"shulker_box":        {0: 6586, 1: 6587, 2: 6588, 3: 6589, 4: 6590, 5: 6591, 6: 6592, 7: 6593, 8: 6594, 9: 6595, 10: 6596, 11: 6597, 12: 6598, 13: 6599, 14: 6600, 15: 6601},
 }
 
 /*
@@ -73,247 +97,294 @@ isSigned    90
 */
 
 func (bdump *BDumpLegacy) formatBlocks() {
-	min:=[]int{2147483647,2147483647,2147483647}
+	min := []int{2147483647, 2147483647, 2147483647}
 	for _, mdl := range bdump.Blocks {
-		if mdl.Point.X<min[0] {
-			min[0]=mdl.Point.X
+		if mdl.Point.X < min[0] {
+			min[0] = mdl.Point.X
 		}
-		if mdl.Point.Y<min[1] {
-			min[1]=mdl.Point.Y
+		if mdl.Point.Y < min[1] {
+			min[1] = mdl.Point.Y
 		}
-		if mdl.Point.Z<min[2] {
-			min[2]=mdl.Point.Z
+		if mdl.Point.Z < min[2] {
+			min[2] = mdl.Point.Z
 		}
 	}
 	for _, mdl := range bdump.Blocks {
-		mdl.Point.X-=min[0]
-		mdl.Point.Y-=min[1]
-		mdl.Point.Z-=min[2]
+		mdl.Point.X -= min[0]
+		mdl.Point.Y -= min[1]
+		mdl.Point.Z -= min[2]
 	}
 }
 
 func (bdump *BDumpLegacy) writeHeader(w *bytes.Buffer) error {
-	_, err:=w.Write([]byte("BDX"))
-	if err!=nil {
+	_, err := w.Write([]byte("BDX"))
+	if err != nil {
 		return err
 	}
-	_, err=w.Write([]byte{0})
-	if err!=nil {
+	// 内部文件头
+	_, err = w.Write([]byte{0})
+	if err != nil {
 		return err
 	}
-	// No author info
-	_, err=w.Write([]byte{0})
+	_, err = w.Write([]byte{0})
+	if err != nil {
+		return err
+	}
+	// 写入作者之名
+	// 注：现在不再写入作者信息
+	_, err = w.Write([]byte{0x1f, 0x75})
 	return err
+	// 放置容器需要用到 117 号的 RunTimeId 调色板表
 }
 
 func (bdump *BDumpLegacy) writeBlocks(w *bytes.Buffer) error {
 	bdump.formatBlocks()
-	brushPosition:=[]int{0,0,0}
-	blocksPalette:=make(map[string]int)
+	brushPosition := []int{0, 0, 0}
+	blocksPalette := make(map[string]int)
 	cursor := 0
-	writer:=&BDumpWriter{writer:w}
+	writer := &BDumpWriter{writer: w}
 	for _, mdl := range bdump.Blocks {
-		blknm:=*mdl.Block.Name
+		blknm := *mdl.Block.Name
 		_, found := blocksPalette[blknm]
 		if found {
 			continue
 		}
-		err:=writer.WriteCommand(&command.CreateConstantString {
+		err := writer.WriteCommand(&command.CreateConstantString{
 			ConstantString: blknm,
 		})
-		if (err != nil) {
+		if err != nil {
 			return err
 		}
-		blocksPalette[blknm]=cursor;
+		blocksPalette[blknm] = cursor
 		cursor++
 	}
-	for _,mdl := range bdump.Blocks {
+	for _, mdl := range bdump.Blocks {
 		for {
-			if(mdl.Point.X!=brushPosition[0]) {
-				if(mdl.Point.X-brushPosition[0]==1){
-					err:=writer.WriteCommand(&command.AddXValue{})
+			if mdl.Point.X != brushPosition[0] {
+				if mdl.Point.X-brushPosition[0] == 1 {
+					err := writer.WriteCommand(&command.AddXValue{})
 					if err != nil {
 						return err
 					}
-				}else if(mdl.Point.X-brushPosition[0]==-1){
-					err:=writer.WriteCommand(&command.SubtractXValue{})
+				} else if mdl.Point.X-brushPosition[0] == -1 {
+					err := writer.WriteCommand(&command.SubtractXValue{})
 					if err != nil {
 						return err
 					}
-				}else{
-					wrap:=mdl.Point.X-brushPosition[0]
-					if (wrap < -32768||wrap > 32767) {
-						err:=writer.WriteCommand(&command.AddInt32XValue {
+				} else {
+					wrap := mdl.Point.X - brushPosition[0]
+					if wrap < -32768 || wrap > 32767 {
+						err := writer.WriteCommand(&command.AddInt32XValue{
 							Value: int32(wrap),
 						})
-						if err!=nil {
+						if err != nil {
 							return err
 						}
-					}else if(wrap < -127||wrap > 127){
-						err:=writer.WriteCommand(&command.AddInt16XValue {
+					} else if wrap < -127 || wrap > 127 {
+						err := writer.WriteCommand(&command.AddInt16XValue{
 							Value: int16(wrap),
 						})
-						if err!=nil {
+						if err != nil {
 							return err
 						}
-					}else{
-						err:=writer.WriteCommand(&command.AddInt8XValue {
+					} else {
+						err := writer.WriteCommand(&command.AddInt8XValue{
 							Value: int8(wrap),
 						})
-						if err!=nil {
+						if err != nil {
 							return err
 						}
 					}
 				}
-				brushPosition[0]=mdl.Point.X
+				brushPosition[0] = mdl.Point.X
 				continue
-			}else if(mdl.Point.Y!=brushPosition[1]) {
-				if(mdl.Point.Y-brushPosition[1]==1){
-					err:=writer.WriteCommand(&command.AddYValue{})
-					if err!=nil {
+			} else if mdl.Point.Y != brushPosition[1] {
+				if mdl.Point.Y-brushPosition[1] == 1 {
+					err := writer.WriteCommand(&command.AddYValue{})
+					if err != nil {
 						return err
 					}
-				}else if(mdl.Point.Y-brushPosition[1]==-1){
-					err:=writer.WriteCommand(&command.SubtractYValue{})
-					if err!=nil {
+				} else if mdl.Point.Y-brushPosition[1] == -1 {
+					err := writer.WriteCommand(&command.SubtractYValue{})
+					if err != nil {
 						return err
 					}
-				}else{
-					wrap:=mdl.Point.Y-brushPosition[1]
-					if (wrap > 32767||wrap < -32768) {
-						err:=writer.WriteCommand(&command.AddInt32YValue {
+				} else {
+					wrap := mdl.Point.Y - brushPosition[1]
+					if wrap > 32767 || wrap < -32768 {
+						err := writer.WriteCommand(&command.AddInt32YValue{
 							Value: int32(wrap),
 						})
-						if err!=nil {
+						if err != nil {
 							return err
 						}
-					}else if(wrap > 127||wrap < -127){
-						err:=writer.WriteCommand(&command.AddInt16YValue {
+					} else if wrap > 127 || wrap < -127 {
+						err := writer.WriteCommand(&command.AddInt16YValue{
 							Value: int16(wrap),
 						})
-						if err!=nil {
+						if err != nil {
 							return err
 						}
-					}else{
-						err:=writer.WriteCommand(&command.AddInt8YValue {
+					} else {
+						err := writer.WriteCommand(&command.AddInt8YValue{
 							Value: int8(wrap),
 						})
-						if err!=nil {
+						if err != nil {
 							return err
 						}
 					}
 				}
-				brushPosition[1]=mdl.Point.Y
+				brushPosition[1] = mdl.Point.Y
 				continue
-			}else if(mdl.Point.Z!=brushPosition[2]) {
-				if(mdl.Point.Z-brushPosition[2]==1){
-					err:=writer.WriteCommand(&command.AddZValue{})
-					if err!=nil {
+			} else if mdl.Point.Z != brushPosition[2] {
+				if mdl.Point.Z-brushPosition[2] == 1 {
+					err := writer.WriteCommand(&command.AddZValue{})
+					if err != nil {
 						return err
 					}
-				}else if(mdl.Point.Z-brushPosition[2]==1){
-					err:=writer.WriteCommand(&command.SubtractZValue{})
-					if err!=nil {
+				} else if mdl.Point.Z-brushPosition[2] == 1 {
+					err := writer.WriteCommand(&command.SubtractZValue{})
+					if err != nil {
 						return err
 					}
-				}else{
-					wrap:=mdl.Point.Z-brushPosition[2]
-					if (wrap > 32767||wrap < -32768) {
-						err:=writer.WriteCommand(&command.AddInt32ZValue {
+				} else {
+					wrap := mdl.Point.Z - brushPosition[2]
+					if wrap > 32767 || wrap < -32768 {
+						err := writer.WriteCommand(&command.AddInt32ZValue{
 							Value: int32(wrap),
 						})
-						if err!=nil {
+						if err != nil {
 							return err
 						}
-					}else if(wrap > 127||wrap < -127){
-						err:=writer.WriteCommand(&command.AddInt16ZValue {
+					} else if wrap > 127 || wrap < -127 {
+						err := writer.WriteCommand(&command.AddInt16ZValue{
 							Value: int16(wrap),
 						})
-						if err!=nil {
+						if err != nil {
 							return err
 						}
-					}else{
-						err:=writer.WriteCommand(&command.AddInt8ZValue {
+					} else {
+						err := writer.WriteCommand(&command.AddInt8ZValue{
 							Value: int8(wrap),
 						})
-						if err!=nil {
+						if err != nil {
 							return err
 						}
 					}
 				}
-				brushPosition[2]=mdl.Point.Z
+				brushPosition[2] = mdl.Point.Z
 			}
 			break
 		}
+		// 移动画笔
+		var placeNormalBlock bool = true
+		// 这个选项会决定这个方块是否以普通情况放置
+		// 你可能说为什么不用 continue ，因为我希望无论如何都记录方块实体数据，而且永远都记录在方块的后面
+		if mdl.ChestData != nil {
+			secondMap, ok := containerIndex[*mdl.Block.Name]
+			if ok {
+				runTimeIdIn117, ok := secondMap[int(mdl.Block.Data)]
+				if ok {
+					err := writer.WriteCommand(&command.PlaceRuntimeBlockWithChestDataAndUint32RuntimeID{
+						BlockRuntimeID: uint32(runTimeIdIn117),
+						ChestSlots:     *mdl.ChestData,
+					})
+					if err != nil {
+						return err
+					}
+					placeNormalBlock = false
+				}
+			}
+		}
+		// 容器
 		if mdl.CommandBlockData != nil {
-			err:=writer.WriteCommand(&command.PlaceCommandBlockWithCommandBlockData {
-				BlockData: uint16(mdl.Block.Data),
+			err := writer.WriteCommand(&command.PlaceCommandBlockWithCommandBlockData{
+				BlockData:        uint16(mdl.Block.Data),
 				CommandBlockData: mdl.CommandBlockData,
 			})
-			if err!=nil {
+			if err != nil {
 				return err
 			}
-			continue
+			placeNormalBlock = false
 		}
-		err:=writer.WriteCommand(&command.PlaceBlock {
-			BlockConstantStringID: uint16(blocksPalette[*mdl.Block.Name]),
-			BlockData: uint16(mdl.Block.Data),
-		})
-		if(err!=nil){
-			return err
+		// 命令方块；且优先级比箱子更高一些
+		if placeNormalBlock {
+			if mdl.Block.BlockStates == nil {
+				err := writer.WriteCommand(&command.PlaceBlock{
+					BlockConstantStringID: uint16(blocksPalette[*mdl.Block.Name]),
+					BlockData:             uint16(mdl.Block.Data),
+				})
+				if err != nil {
+					return err
+				}
+				// 以方块数据值(附加值)为依据放置方块
+			} else {
+				err := writer.WriteCommand(&command.PlaceBlockWithBlockStates{
+					BlockConstantStringID: uint16(blocksPalette[*mdl.Block.Name]),
+					BlockStatesString:     *mdl.Block.BlockStates,
+				})
+				if err != nil {
+					return err
+				}
+				// 以方块状态为依据放置方块
+				// 我更推荐使用这一个方式来放置方块，因为方块数据值(附加值)已不再在新版本 MC 中使用
+				// ——Happy2018new
+			}
 		}
+		// 常规方块写入
 		if mdl.NBTData != nil {
-			err:=writer.WriteCommand(&command.AssignNBTData {
+			err := writer.WriteCommand(&command.AssignNBTData{
 				Data: mdl.NBTData,
 			})
 			if err != nil {
 				return err
 			}
 		}
+		// 写入方块实体数据
 	}
 	return nil
 }
 
 func (bdump *BDumpLegacy) WriteToFile(path string, localCert string, localKey string) (error, error) {
-	file, err:=os.OpenFile(path, os.O_RDWR|os.O_TRUNC|os.O_CREATE,0666)
-	if err!=nil {
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_TRUNC|os.O_CREATE, 0666)
+	if err != nil {
 		return fmt.Errorf("Failed to open file: %v", err), nil
 	}
 	defer file.Close()
-	_, err=file.Write([]byte("BD@"))
-	if err!=nil {
+	_, err = file.Write([]byte("BD@"))
+	if err != nil {
 		return fmt.Errorf("Failed to write BRBDP file header"), nil
 	}
-	buffer:=&bytes.Buffer{}
+	buffer := &bytes.Buffer{}
 	brw := brotli.NewWriter(file)
-	err=bdump.writeHeader(buffer)
-	if err!=nil {
+	err = bdump.writeHeader(buffer)
+	if err != nil {
 		return err, nil
 	}
-	err=bdump.writeBlocks(buffer)
-	if err!=nil {
+	err = bdump.writeBlocks(buffer)
+	if err != nil {
 		return err, nil
 	}
-	bts:=buffer.Bytes()
-	_, err=brw.Write(bts)
-	if(err!=nil) {
+	bts := buffer.Bytes()
+	_, err = brw.Write(bts)
+	if err != nil {
 		return err, nil
 	}
-	sign, signerr:=SignBDX(bts, localKey, localCert)
-	if(signerr!=nil) {
+	sign, signerr := SignBDX(bts, localKey, localCert)
+	if signerr != nil {
 		brw.Write([]byte("XE"))
-	}else{
+	} else {
 		brw.Write(append([]byte{88}, sign...))
-		if(len(sign)>=255) {
-			realLength:=make([]byte,2)
-			binary.BigEndian.PutUint16(realLength,uint16(len(sign)))
+		if len(sign) >= 255 {
+			realLength := make([]byte, 2)
+			binary.BigEndian.PutUint16(realLength, uint16(len(sign)))
 			brw.Write(realLength)
 			brw.Write([]byte{uint8(255)})
-		}else{
+		} else {
 			brw.Write([]byte{uint8(len(sign))})
 		}
 		brw.Write([]byte{90})
 	}
-	err=brw.Close()
+	err = brw.Close()
 	return err, signerr
 }

--- a/fastbuilder/builder/bdump.go
+++ b/fastbuilder/builder/bdump.go
@@ -1,16 +1,16 @@
 package builder
 
 import (
-	"io"
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"io"
 	"phoenixbuilder/fastbuilder/bdump"
+	"phoenixbuilder/fastbuilder/bdump/command"
 	bridge_path "phoenixbuilder/fastbuilder/builder/path"
 	I18n "phoenixbuilder/fastbuilder/i18n"
 	"phoenixbuilder/fastbuilder/types"
 	"phoenixbuilder/fastbuilder/world_provider"
-	"phoenixbuilder/fastbuilder/bdump/command"
 
 	"github.com/andybalholm/brotli"
 )
@@ -105,15 +105,15 @@ func BDump(config *types.MainConfig, blc chan *types.Module) error {
 	var runtimeIdPoolUsing []*types.ConstBlock
 	//var prevCmd command.Command = nil
 	for {
-		_cmd, err:=command.ReadCommand(br)
+		_cmd, err := command.ReadCommand(br)
 		if err != nil {
 			return fmt.Errorf("%s: %v", I18n.T(I18n.BDump_FailedToGetConstructCmd), err)
 		}
-		_, isTerminate:=_cmd.(*command.Terminate)
+		_, isTerminate := _cmd.(*command.Terminate)
 		if isTerminate {
 			break
 		}
-		switch cmd:=_cmd.(type) {
+		switch cmd := _cmd.(type) {
 		case *command.CreateConstantString:
 			blocksStrPool = append(blocksStrPool, cmd.ConstantString)
 		case *command.AddInt16ZValue0:
@@ -222,7 +222,7 @@ func BDump(config *types.MainConfig, blc chan *types.Module) error {
 				return fmt.Errorf("This file is using an unknown runtime id pool, we're unable to resolve it.")
 			}
 		case *command.PlaceRuntimeBlock:
-			if int(cmd.BlockRuntimeID)>=len(runtimeIdPoolUsing) {
+			if int(cmd.BlockRuntimeID) >= len(runtimeIdPoolUsing) {
 				return fmt.Errorf("Fatal: Block with runtime ID %d not found", cmd.BlockRuntimeID)
 			}
 			blc <- &types.Module{
@@ -234,7 +234,7 @@ func BDump(config *types.MainConfig, blc chan *types.Module) error {
 				},
 			}
 		case *command.PlaceRuntimeBlockWithUint32RuntimeID:
-			if int(cmd.BlockRuntimeID)>=len(runtimeIdPoolUsing) {
+			if int(cmd.BlockRuntimeID) >= len(runtimeIdPoolUsing) {
 				return fmt.Errorf("Fatal: Block with runtime ID %d not found", cmd.BlockRuntimeID)
 			}
 			blc <- &types.Module{
@@ -246,12 +246,12 @@ func BDump(config *types.MainConfig, blc chan *types.Module) error {
 				},
 			}
 		case *command.PlaceRuntimeBlockWithCommandBlockData:
-			if int(cmd.BlockRuntimeID)>=len(runtimeIdPoolUsing) {
+			if int(cmd.BlockRuntimeID) >= len(runtimeIdPoolUsing) {
 				return fmt.Errorf("Fatal: Block with runtime ID %d not found", cmd.BlockRuntimeID)
 			}
-			cmdl:=&types.Module {
+			cmdl := &types.Module{
 				Block: runtimeIdPoolUsing[int(cmd.BlockRuntimeID)].Take(),
-				Point: types.Position {
+				Point: types.Position{
 					X: brushPosition[0] + config.Position.X,
 					Y: brushPosition[1] + config.Position.Y,
 					Z: brushPosition[2] + config.Position.Z,
@@ -260,12 +260,12 @@ func BDump(config *types.MainConfig, blc chan *types.Module) error {
 			}
 			blc <- cmdl
 		case *command.PlaceRuntimeBlockWithCommandBlockDataAndUint32RuntimeID:
-			if int(cmd.BlockRuntimeID)>=len(runtimeIdPoolUsing) {
+			if int(cmd.BlockRuntimeID) >= len(runtimeIdPoolUsing) {
 				return fmt.Errorf("Fatal: Block with runtime ID %d not found", cmd.BlockRuntimeID)
 			}
-			cmdl:=&types.Module {
+			cmdl := &types.Module{
 				Block: runtimeIdPoolUsing[cmd.BlockRuntimeID].Take(),
-				Point: types.Position {
+				Point: types.Position{
 					X: brushPosition[0] + config.Position.X,
 					Y: brushPosition[1] + config.Position.Y,
 					Z: brushPosition[2] + config.Position.Z,
@@ -274,10 +274,10 @@ func BDump(config *types.MainConfig, blc chan *types.Module) error {
 			}
 			blc <- cmdl
 		case *command.PlaceRuntimeBlockWithChestData:
-			if int(cmd.BlockRuntimeID)>=len(runtimeIdPoolUsing) {
+			if int(cmd.BlockRuntimeID) >= len(runtimeIdPoolUsing) {
 				return fmt.Errorf("Fatal: Block with runtime ID %d not found", cmd.BlockRuntimeID)
 			}
-			pos:=types.Position{
+			pos := types.Position{
 				X: brushPosition[0] + config.Position.X,
 				Y: brushPosition[1] + config.Position.Y,
 				Z: brushPosition[2] + config.Position.Z,
@@ -294,10 +294,10 @@ func BDump(config *types.MainConfig, blc chan *types.Module) error {
 				}
 			}
 		case *command.PlaceRuntimeBlockWithChestDataAndUint32RuntimeID:
-			if int(cmd.BlockRuntimeID)>=len(runtimeIdPoolUsing) {
+			if int(cmd.BlockRuntimeID) >= len(runtimeIdPoolUsing) {
 				return fmt.Errorf("Fatal: Block with runtime ID %d not found", cmd.BlockRuntimeID)
 			}
-			pos:=types.Position{
+			pos := types.Position{
 				X: brushPosition[0] + config.Position.X,
 				Y: brushPosition[1] + config.Position.Y,
 				Z: brushPosition[2] + config.Position.Z,
@@ -322,8 +322,8 @@ func BDump(config *types.MainConfig, blc chan *types.Module) error {
 			blockName := &blocksStrPool[int(cmd.BlockConstantStringID)]
 			blc <- &types.Module{
 				Block: &types.Block{
-					Name: blockName,
-					BlockStates: cmd.BlockStatesString,
+					Name:        blockName,
+					BlockStates: &cmd.BlockStatesString,
 				},
 				Point: types.Position{
 					X: brushPosition[0] + config.Position.X,

--- a/fastbuilder/commands_generator/setblock.go
+++ b/fastbuilder/commands_generator/setblock.go
@@ -10,14 +10,13 @@ func SetBlockRequest(module *types.Module, config *types.MainConfig) string {
 	Point := module.Point
 	Method := config.Method
 	if Block != nil {
-		if len(Block.BlockStates)!=0 {
-			return fmt.Sprintf("setblock %d %d %d %s %s %s", Point.X, Point.Y, Point.Z, *Block.Name, Block.BlockStates, Method)
-		}else{
+		if Block.BlockStates != nil {
+			return fmt.Sprintf("setblock %d %d %d %s %s %s", Point.X, Point.Y, Point.Z, *Block.Name, *Block.BlockStates, Method)
+		} else {
 			return fmt.Sprintf("setblock %d %d %d %s %d %s", Point.X, Point.Y, Point.Z, *Block.Name, Block.Data, Method)
 		}
 	} else {
 		return fmt.Sprintf("setblock %d %d %d %s %d %s", Point.X, Point.Y, Point.Z, config.Block.Name, config.Block.Data, Method)
 	}
-	
-}
 
+}

--- a/fastbuilder/types/block.go
+++ b/fastbuilder/types/block.go
@@ -1,48 +1,47 @@
 package types
 
-
 type Module struct {
-	Block  *Block
+	Block            *Block
 	CommandBlockData *CommandBlockData
-	NBTData []byte
+	NBTData          []byte
 	//Entity *Entity
 	ChestSlot *ChestSlot
 	ChestData *ChestData
-	Point  Position
+	Point     Position
 }
 
 type RuntimeModule struct {
-	BlockRuntimeId uint32 // The current total count of runtime ids didn't exceed 65536
+	BlockRuntimeId   uint32 // The current total count of runtime ids didn't exceed 65536
 	CommandBlockData *CommandBlockData
-	ChestData *ChestData
-	Point Position
+	ChestData        *ChestData
+	Point            Position
 }
 
 type Block struct {
-	Name *string
-	BlockStates string
-	Data uint16
+	Name        *string
+	BlockStates *string
+	Data        uint16
 }
 
 type CommandBlockData struct {
-	Mode uint32
-	Command string
-	CustomName string
-	LastOutput string
-	TickDelay int32
+	Mode               uint32
+	Command            string
+	CustomName         string
+	LastOutput         string
+	TickDelay          int32
 	ExecuteOnFirstTick bool //byte
-	TrackOutput bool //byte
-	Conditional bool
-	NeedRedstone bool
+	TrackOutput        bool //byte
+	Conditional        bool
+	NeedRedstone       bool
 }
 
 type ChestData []ChestSlot
 
 type ChestSlot struct {
-	Name string
-	Count uint8
+	Name   string
+	Count  uint8
 	Damage uint16
-	Slot uint8
+	Slot   uint8
 }
 
 type ConstBlock struct {
@@ -58,13 +57,14 @@ type DoubleModule struct {
 }
 
 var takenBlocks map[*ConstBlock]*Block = make(map[*ConstBlock]*Block)
-const takenBlocksMaxSize=1024
-const takenBlocksDeleteCount=512
 
-func CreateBlock(name string,data uint16) *Block {
-	return &Block {
-		Name:&name,
-		Data:data,
+const takenBlocksMaxSize = 1024
+const takenBlocksDeleteCount = 512
+
+func CreateBlock(name string, data uint16) *Block {
+	return &Block{
+		Name: &name,
+		Data: data,
 	}
 }
 
@@ -73,9 +73,9 @@ func (req *ConstBlock) Take() *Block {
 	if ok {
 		return block
 	}
-	if(len(takenBlocks)>takenBlocksMaxSize) {
-		i:=0
-		for k,_ := range takenBlocks {
+	if len(takenBlocks) > takenBlocksMaxSize {
+		i := 0
+		for k, _ := range takenBlocks {
 			delete(takenBlocks, k)
 			i++
 			if i >= takenBlocksDeleteCount {
@@ -83,10 +83,10 @@ func (req *ConstBlock) Take() *Block {
 			}
 		}
 	}
-	block=&Block {
-		Name:&req.Name, //ConstBlock won't be destroyed
-		Data:req.Data,
+	block = &Block{
+		Name: &req.Name, //ConstBlock won't be destroyed
+		Data: req.Data,
 	}
-	takenBlocks[req]=block
+	takenBlocks[req] = block
 	return block
 }

--- a/io/special_tasks/define.go
+++ b/io/special_tasks/define.go
@@ -1,0 +1,93 @@
+//go:build !is_tweak
+// +build !is_tweak
+
+package special_tasks
+
+import (
+	"fmt"
+	"io"
+	"math"
+)
+
+type SolidSimplePos struct {
+	X int64 `json:"x"`
+	Y int64 `json:"y"`
+	Z int64 `json:"z"`
+}
+
+type SolidRet struct {
+	BlockName  string         `json:"blockName"`
+	Position   SolidSimplePos `json:"position"`
+	StatusCode int64          `json:"statusCode"`
+}
+
+var ExportWaiter chan map[string]interface{}
+
+type byteAndNormalReader interface {
+	io.Reader
+	io.ByteReader
+}
+
+func readVarint32(reader byteAndNormalReader) (int32, error) {
+	// Copied code, from gophertunnel
+	var val uint32
+	for i := uint(0); i < 35; i += 7 {
+		b, err := reader.ReadByte()
+		if err != nil {
+			return 0, fmt.Errorf("Early EOF")
+		}
+		val |= uint32(b&0x7f) << i
+		if b&0x80 == 0 {
+			break
+		}
+	}
+	ret_val := int32(val >> 1)
+	if ret_val&1 != 0 {
+		ret_val = ^ret_val
+	}
+	return ret_val, nil
+}
+
+func readVarint64(reader byteAndNormalReader) (int64, error) {
+	// Copied code, from gophertunnel
+	var val uint64
+	for i := uint(0); i < 70; i += 7 {
+		b, err := reader.ReadByte()
+		if err != nil {
+			return 0, fmt.Errorf("Early EOF")
+		}
+		val |= uint64(b&0x7f) << i
+		if b&0x80 == 0 {
+			break
+		}
+	}
+	rval := int64(val >> 1)
+	if rval&1 != 0 {
+		rval = ^rval
+	}
+	return rval, nil
+}
+
+func readNBTString(reader byteAndNormalReader) (string, error) {
+	// Code mainly from gophertunnel
+	var length uint32
+	for i := uint(0); i < 35; i += 7 {
+		b, err := reader.ReadByte()
+		if err != nil {
+			return "", fmt.Errorf("Early EOF")
+		}
+		length |= uint32(b&0x7f) << i
+		if b&0x80 == 0 {
+			break
+		}
+	}
+	if length > math.MaxInt16 {
+		return "", fmt.Errorf("Invalid string length")
+	}
+	buf := make([]byte, length)
+	_, err := io.ReadAtLeast(reader, buf, int(length))
+	if err != nil {
+		return "", fmt.Errorf("Early EOF")
+	}
+	return string(buf), nil
+}

--- a/io/special_tasks/export.go
+++ b/io/special_tasks/export.go
@@ -1,13 +1,11 @@
+//go:build !is_tweak
 // +build !is_tweak
 
 package special_tasks
 
 import (
-	"io"
-	"fmt"
-	"time"
-	"math"
 	"bytes"
+	"fmt"
 	"phoenixbuilder/fastbuilder/bdump"
 	"phoenixbuilder/fastbuilder/configuration"
 	"phoenixbuilder/fastbuilder/environment"
@@ -15,228 +13,142 @@ import (
 	"phoenixbuilder/fastbuilder/task"
 	"phoenixbuilder/fastbuilder/task/fetcher"
 	"phoenixbuilder/fastbuilder/types"
+	"phoenixbuilder/minecraft/protocol/packet"
 	"phoenixbuilder/mirror"
+	"phoenixbuilder/mirror/chunk"
 	"phoenixbuilder/mirror/define"
 	"phoenixbuilder/mirror/io/global"
-	"phoenixbuilder/mirror/io/world"
-	"phoenixbuilder/minecraft"
-	"phoenixbuilder/minecraft/protocol"
-	"phoenixbuilder/minecraft/protocol/packet"
 	"phoenixbuilder/mirror/io/lru"
-	"phoenixbuilder/mirror/chunk"
-	"runtime/debug"
+	"phoenixbuilder/mirror/io/world"
 	"runtime"
-	"strconv"
+	"runtime/debug"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/pterm/pterm"
 )
 
-
-type SolidSimplePos struct {
-	X int64 `json:"x"`
-	Y int64 `json:"y"`
-	Z int64 `json:"z"`
-}
-
-type SolidRet struct {
-	BlockName string `json:"blockName"`
-	Position SolidSimplePos `json:"position"`
-	StatusCode int64 `json:"statusCode"`
-}
-
-var ExportWaiter chan map[string]interface{}
-
-type byteAndNormalReader interface {
-	io.Reader
-	io.ByteReader
-}
-
-func readVarint32(reader byteAndNormalReader) (int32, error) {
-	// Copied code, from gophertunnel
-	var val uint32
-	for i:=uint(0);i<35;i+=7 {
-		b, err:=reader.ReadByte()
-		if(err!=nil) {
-			return 0, fmt.Errorf("Early EOF")
-		}
-		val|=uint32(b&0x7f)<<i
-		if b&0x80==0 {
-			break
-		}
-	}
-	ret_val:=int32(val>>1)
-	if ret_val&1!=0 {
-		ret_val= ^ret_val
-	}
-	return ret_val, nil
-}
-
-func readVarint64(reader byteAndNormalReader) (int64, error) {
-	// Copied code, from gophertunnel
-	var val uint64
-	for i:=uint(0);i<70;i+=7 {
-		b, err:=reader.ReadByte()
-		if(err!=nil) {
-			return 0, fmt.Errorf("Early EOF")
-		}
-		val|=uint64(b&0x7f)<<i
-		if b&0x80==0 {
-			break
-		}
-	}
-	rval:=int64(val>>1)
-	if rval&1!=0 {
-		rval= ^rval
-	}
-	return rval, nil
-}
-
-func readNBTString(reader byteAndNormalReader) (string, error) {
-	// Code mainly from gophertunnel
-	var length uint32
-	for i:=uint(0);i<35;i+=7 {
-		b, err:=reader.ReadByte()
-		if(err!=nil) {
-			return "", fmt.Errorf("Early EOF")
-		}
-		length|=uint32(b&0x7f)<<i
-		if b&0x80==0 {
-			break
-		}
-	}
-	if length>math.MaxInt16 {
-		return "", fmt.Errorf("Invalid string length")
-	}
-	buf:=make([]byte, length)
-	_, err:=io.ReadAtLeast(reader, buf, int(length))
-	if err!=nil {
-		return "", fmt.Errorf("Early EOF")
-	}
-	return string(buf), nil
-}
-
 func CreateExportTask(commandLine string, env *environment.PBEnvironment) *task.Task {
-	cmdsender:=env.CommandSender
+	cmdsender := env.CommandSender
 	// WIP
 	//cmdsender.Output("Sorry, but compatibility works haven't been done yet, redirected to lexport.")
 	//return CreateLegacyExportTask(commandLine, env)
 	cfg, err := parsing.Parse(commandLine, configuration.GlobalFullConfig(env).Main())
-	if err!=nil {
-		cmdsender.Output(fmt.Sprintf("Failed to parse command: %v",err))
+	if err != nil {
+		cmdsender.Output(fmt.Sprintf("Failed to parse command: %v", err))
 		return nil
 	}
 	//cmdsender.Output("Sorry, but compatibility works haven't been done yet, please use lexport.")
 	//return nil
 	beginPos := cfg.Position
 	endPos := cfg.End
-	startX,endX,startZ,endZ:=0,0,0,0
-	if(endPos.X-beginPos.X<0) {
-		temp:=endPos.X
-		endPos.X=beginPos.X
-		beginPos.X=temp
+	startX, endX, startZ, endZ := 0, 0, 0, 0
+	if endPos.X-beginPos.X < 0 {
+		temp := endPos.X
+		endPos.X = beginPos.X
+		beginPos.X = temp
 	}
-	startX,endX=beginPos.X,endPos.X
-	if(endPos.Y-beginPos.Y<0) {
-		temp:=endPos.Y
-		endPos.Y=beginPos.Y
-		beginPos.Y=temp
+	startX, endX = beginPos.X, endPos.X
+	if endPos.Y-beginPos.Y < 0 {
+		temp := endPos.Y
+		endPos.Y = beginPos.Y
+		beginPos.Y = temp
 	}
-	if(endPos.Z-beginPos.Z<0) {
-		temp:=endPos.Z
-		endPos.Z=beginPos.Z
-		beginPos.Z=temp
+	if endPos.Z-beginPos.Z < 0 {
+		temp := endPos.Z
+		endPos.Z = beginPos.Z
+		beginPos.Z = temp
 	}
-	startZ,endZ=beginPos.Z,endPos.Z
-	hopPath,requiredChunks:=fetcher.PlanHopSwapPath(startX,startZ,endX,endZ,16)
-	chunkPool:=map[fetcher.ChunkPosDefine]fetcher.ChunkDefine{}
-	memoryCacheFetcher:=fetcher.CreateCacheHitFetcher(requiredChunks,chunkPool)
+	startZ, endZ = beginPos.Z, endPos.Z
+	hopPath, requiredChunks := fetcher.PlanHopSwapPath(startX, startZ, endX, endZ, 16)
+	chunkPool := map[fetcher.ChunkPosDefine]fetcher.ChunkDefine{}
+	memoryCacheFetcher := fetcher.CreateCacheHitFetcher(requiredChunks, chunkPool)
 	env.LRUMemoryChunkCacher.(*lru.LRUMemoryChunkCacher).Iter(func(pos define.ChunkPos, chunk *mirror.ChunkData) (stop bool) {
-		memoryCacheFetcher(fetcher.ChunkPosDefine{int(pos[0])*16,int(pos[1])*16},fetcher.ChunkDefine(chunk))
+		memoryCacheFetcher(fetcher.ChunkPosDefine{int(pos[0]) * 16, int(pos[1]) * 16}, fetcher.ChunkDefine(chunk))
 		return false
 	})
-	hopPath=fetcher.SimplifyHopPos(hopPath)
-	fmt.Println("Hop Left: ",len(hopPath))
-	teleportFn:=func (x,z int)  {
-		cmd:=fmt.Sprintf("tp @s %v 128 %v",x,z)
-		uid,_:=uuid.NewUUID()
-		cmdsender.SendCommand(cmd,uid)
-		cmd=fmt.Sprintf("execute @s ~~~ spreadplayers ~ ~ 3 4 @s")
-		uid,_=uuid.NewUUID()
-		cmdsender.SendCommand(cmd,uid)
+	hopPath = fetcher.SimplifyHopPos(hopPath)
+	fmt.Println("Hop Left: ", len(hopPath))
+	teleportFn := func(x, z int) {
+		cmd := fmt.Sprintf("tp @s %v 128 %v", x, z)
+		uid, _ := uuid.NewUUID()
+		cmdsender.SendCommand(cmd, uid)
+		cmd = fmt.Sprintf("execute @s ~~~ spreadplayers ~ ~ 3 4 @s")
+		uid, _ = uuid.NewUUID()
+		cmdsender.SendCommand(cmd, uid)
 	}
-	feedChan:=make(chan *fetcher.ChunkDefineWithPos,1024)
-	deRegFn:=env.ChunkFeeder.(*global.ChunkFeeder).RegNewReader(func (chunk *mirror.ChunkData)  {
-		feedChan<-&fetcher.ChunkDefineWithPos{Chunk: fetcher.ChunkDefine(chunk),Pos:fetcher.ChunkPosDefine{int(chunk.ChunkPos[0])*16,int(chunk.ChunkPos[1])*16}}
+	feedChan := make(chan *fetcher.ChunkDefineWithPos, 1024)
+	deRegFn := env.ChunkFeeder.(*global.ChunkFeeder).RegNewReader(func(chunk *mirror.ChunkData) {
+		feedChan <- &fetcher.ChunkDefineWithPos{Chunk: fetcher.ChunkDefine(chunk), Pos: fetcher.ChunkPosDefine{int(chunk.ChunkPos[0]) * 16, int(chunk.ChunkPos[1]) * 16}}
 	})
-	inHopping:=true
+	inHopping := true
 	go func() {
 		return
-		yc:=23
+		yc := 23
 		for {
-			if(!inHopping) {
+			if !inHopping {
 				break
 			}
-			uuidval, _:=uuid.NewUUID()
-			yv:=(yc-4)*16+8
+			uuidval, _ := uuid.NewUUID()
+			yv := (yc-4)*16 + 8
 			yc--
-			if yc<0 {
-				yc=23
+			if yc < 0 {
+				yc = 23
 			}
-			cmdsender.SendCommand(fmt.Sprintf("tp @s ~ %d ~", yv),uuidval)
-			time.Sleep(time.Millisecond*50)
+			cmdsender.SendCommand(fmt.Sprintf("tp @s ~ %d ~", yv), uuidval)
+			time.Sleep(time.Millisecond * 50)
 		}
-	} ()
+	}()
 	fmt.Println("Begin Fast Hopping")
-	fetcher.FastHopper(teleportFn,feedChan,chunkPool,hopPath,requiredChunks,0.5,3)
+	fetcher.FastHopper(teleportFn, feedChan, chunkPool, hopPath, requiredChunks, 0.5, 3)
 	fmt.Println("Fast Hopping Done")
 	deRegFn()
-	hopPath=fetcher.SimplifyHopPos(hopPath)
-	fmt.Println("Hop Left: ",len(hopPath))
-	if len(hopPath)>0{
-		fetcher.FixMissing(teleportFn,feedChan,chunkPool,hopPath,requiredChunks,2,3)
+	hopPath = fetcher.SimplifyHopPos(hopPath)
+	fmt.Println("Hop Left: ", len(hopPath))
+	if len(hopPath) > 0 {
+		fetcher.FixMissing(teleportFn, feedChan, chunkPool, hopPath, requiredChunks, 2, 3)
 	}
-	inHopping=false
-	hasMissing:=false
-	for _,c:=range requiredChunks{
-		if !c.CachedMark{
-			hasMissing=true
-			pterm.Error.Printfln("Missing Chunk %v",c.Pos)
+	inHopping = false
+	hasMissing := false
+	for _, c := range requiredChunks {
+		if !c.CachedMark {
+			hasMissing = true
+			pterm.Error.Printfln("Missing Chunk %v", c.Pos)
 		}
 	}
-	if !hasMissing{
+	if !hasMissing {
 		pterm.Success.Println("all chunks successfully fetched!")
 	}
-	providerChunksMap:=make(map[define.ChunkPos]*mirror.ChunkData)
-	for _,chunk:=range chunkPool{
-		providerChunksMap[chunk.ChunkPos]=(*mirror.ChunkData)(chunk)
+	providerChunksMap := make(map[define.ChunkPos]*mirror.ChunkData)
+	for _, chunk := range chunkPool {
+		providerChunksMap[chunk.ChunkPos] = (*mirror.ChunkData)(chunk)
 	}
 	var offlineWorld *world.World
-	offlineWorld=world.NewWorld(SimpleChunkProvider{providerChunksMap})
+	offlineWorld = world.NewWorld(SimpleChunkProvider{providerChunksMap})
 
 	go func() {
 		defer func() {
-			r:=recover()
-			if r!=nil{
+			r := recover()
+			if r != nil {
 				debug.PrintStack()
-				fmt.Println("go routine @ fastbuilder.task export crashed ",r)
+				fmt.Println("go routine @ fastbuilder.task export crashed ", r)
 			}
 		}()
 		cmdsender.Output("EXPORT >> Exporting...")
-		V:=(endPos.X-beginPos.X+1)*(endPos.Y-beginPos.Y+1)*(endPos.Z-beginPos.Z+1)
-		blocks:=make([]*types.Module,V)
-		counter:=0
-		for x:=beginPos.X; x<=endPos.X; x++ {
-			for z:=beginPos.Z; z<=endPos.Z; z++ {
-				for y:=beginPos.Y; y<=endPos.Y; y++ {
-					runtimeId, item, found:=offlineWorld.BlockWithNbt(define.CubePos{x,y,z})
+		V := (endPos.X - beginPos.X + 1) * (endPos.Y - beginPos.Y + 1) * (endPos.Z - beginPos.Z + 1)
+		blocks := make([]*types.Module, V)
+		counter := 0
+		for x := beginPos.X; x <= endPos.X; x++ {
+			for z := beginPos.Z; z <= endPos.Z; z++ {
+				for y := beginPos.Y; y <= endPos.Y; y++ {
+					runtimeId, item, found := offlineWorld.BlockWithNbt(define.CubePos{x, y, z})
 					if !found {
 						fmt.Printf("WARNING %d %d %d not found\n", x, y, z)
 					}
 					//block, item:=blk.EncodeBlock()
 					block, static_item, _ := chunk.RuntimeIDToState(runtimeId)
-					if block=="minecraft:air" {
+					if block == "minecraft:air" {
 						continue
 					}
 					var cbdata *types.CommandBlockData = nil
@@ -262,7 +174,7 @@ func CreateExportTask(commandLine string, env *environment.PBEnvironment) *task.
 						chestData=&chest
 					}*/
 					// TODO ^ Hope someone could help me to do that, just like what I did below ^
-					if strings.Contains(block,"command_block") {
+					if strings.Contains(block, "command_block") {
 						/*
 							=========
 							Reference
@@ -270,10 +182,10 @@ func CreateExportTask(commandLine string, env *environment.PBEnvironment) *task.
 							Types for command blocks are checked by their names
 							Whether a command block is conditional is checked through its data value.
 							SINCE IT IS NOT INCLUDED IN NBT DATA.
-							
+
 							The content of __tag is NBT data w/o keys, flatten placed,
 							in such order:
-							
+
 							isMovable:byte
 							CustomName:string
 							UserCustomData:string
@@ -293,33 +205,33 @@ func CreateExportTask(commandLine string, env *environment.PBEnvironment) *task.
 							TickDelay:VarInt32
 							ExecuteOnFirstTick:byte
 						*/
-						__tag:=[]byte(item["__tag"].(string))
+						__tag := []byte(item["__tag"].(string))
 						//fmt.Printf("CMDBLK %#v\n\n",item["__tag"])
 						var mode uint32
-						if(block=="command_block"||block=="minecraft:command_block"){
-							mode=packet.CommandBlockImpulse
-						}else if(block=="repeating_command_block"||block=="minecraft:repeating_command_block"){
-							mode=packet.CommandBlockRepeating
-						}else if(block=="chain_command_block"||block=="minecraft:chain_command_block"){
-							mode=packet.CommandBlockChain
+						if block == "command_block" || block == "minecraft:command_block" {
+							mode = packet.CommandBlockImpulse
+						} else if block == "repeating_command_block" || block == "minecraft:repeating_command_block" {
+							mode = packet.CommandBlockRepeating
+						} else if block == "chain_command_block" || block == "minecraft:chain_command_block" {
+							mode = packet.CommandBlockChain
 						}
-						tagContent:=bytes.NewBuffer(__tag)
+						tagContent := bytes.NewBuffer(__tag)
 						tagContent.Next(1)
 						// ^ Skip: [isMovable:byte]
-						_, err:=readNBTString(tagContent)
-						if err!=nil {
+						_, err := readNBTString(tagContent)
+						if err != nil {
 							panic(err)
 						}
 						// ^ Skip: [CustomName:string]
-						_, err=readNBTString(tagContent)
-						if err!=nil {
+						_, err = readNBTString(tagContent)
+						if err != nil {
 							panic(err)
 						}
 						// ^ Skip: [UserCustomData:string]
 						tagContent.Next(1)
 						// ^ Skip: [powered:byte]
-						aut, err:=tagContent.ReadByte()
-						if err!=nil {
+						aut, err := tagContent.ReadByte()
+						if err != nil {
 							panic(err)
 						}
 						// ^ Read: [auto:byte]
@@ -328,114 +240,114 @@ func CreateExportTask(commandLine string, env *environment.PBEnvironment) *task.
 						//   Skip: [LPConditionMode:byte]
 						//   Skip: [LPRedstoneMode:byte]
 						//   Skip: [LPCommandMode:byte]
-						cmd, err:=readNBTString(tagContent)
-						if err!=nil {
+						cmd, err := readNBTString(tagContent)
+						if err != nil {
 							panic(err)
 						}
 						// ^ Read: [Command:string]
-						_, err=readVarint32(tagContent)
-						if err!=nil {
+						_, err = readVarint32(tagContent)
+						if err != nil {
 							panic(err)
 						}
 						// ^ Skip: [Version:VarInt32]
-						cusname, err:=readNBTString(tagContent)
-						if err!=nil {
+						cusname, err := readNBTString(tagContent)
+						if err != nil {
 							panic(err)
 						}
 						// ^ Read: [CustomName:string]
-						lo, err:=readNBTString(tagContent)
-						if err!=nil {
+						lo, err := readNBTString(tagContent)
+						if err != nil {
 							panic(err)
 						}
 						// ^ Read: [LastOutput:string]
-						lop_in, err:=readVarint32(tagContent)
-						if err!=nil {
+						lop_in, err := readVarint32(tagContent)
+						if err != nil {
 							panic(err)
 						}
 						// ^ PartialRead: **LENGTH OF** [LastOutputParams:list[string]]
-						for i:=0;i<int(lop_in);i++ {
-							_, err=readNBTString(tagContent)
-							if err!=nil {
+						for i := 0; i < int(lop_in); i++ {
+							_, err = readNBTString(tagContent)
+							if err != nil {
 								panic(err)
 							}
 							// ^ PartialRead: **CONTENT OF** [LastOutputParams:list[string]]
 						}
 						// ^ Skip: [LastOutputParams:list[string]]
-						trackoutput, err:=tagContent.ReadByte()
-						if err!=nil {
+						trackoutput, err := tagContent.ReadByte()
+						if err != nil {
 							panic(err)
 						}
 						// ^ Read: [TrackOutput:byte]
-						_, err=readVarint64(tagContent)
-						if err!=nil {
+						_, err = readVarint64(tagContent)
+						if err != nil {
 							panic(err)
 						}
 						// ^ Skip: [LastExecution:VarInt64]
-						tickdelay, err:=readVarint32(tagContent)
-						if err!=nil {
+						tickdelay, err := readVarint32(tagContent)
+						if err != nil {
 							panic(err)
 						}
 						// ^ Read: [TickDelay:VarInt32]
-						exeft, err:=tagContent.ReadByte()
-						if err!=nil {
+						exeft, err := tagContent.ReadByte()
+						if err != nil {
 							panic(err)
 						}
 						// ^ Read: [ExecuteOnFirstTick:byte]
-						if tagContent.Len()!=0 {
+						if tagContent.Len() != 0 {
 							panic("Unterminated command block tag")
 						}
-						conb_bit:=static_item["conditional_bit"].(uint8)
-						conb:=false
-						if conb_bit==1 {
-							conb=true
+						conb_bit := static_item["conditional_bit"].(uint8)
+						conb := false
+						if conb_bit == 1 {
+							conb = true
 						}
 						var exeftb bool
-						if exeft==0 {
-							exeftb=true
-						}else{
-							exeftb=true
+						if exeft == 0 {
+							exeftb = true
+						} else {
+							exeftb = true
 						}
 						var tob bool
-						if trackoutput==1 {
-							tob=true
-						}else{
-							tob=false
+						if trackoutput == 1 {
+							tob = true
+						} else {
+							tob = false
 						}
 						var nrb bool
-						if aut==1 {
-							nrb=false
+						if aut == 1 {
+							nrb = false
 							//REVERSED!!
-						}else{
-							nrb=true
+						} else {
+							nrb = true
 						}
-						cbdata=&types.CommandBlockData {
-							Mode: mode,
-							Command: cmd,
-							CustomName: cusname,
+						cbdata = &types.CommandBlockData{
+							Mode:               mode,
+							Command:            cmd,
+							CustomName:         cusname,
 							ExecuteOnFirstTick: exeftb,
-							LastOutput: lo,
-							TickDelay: tickdelay,
-							TrackOutput: tob,
-							Conditional: conb,
-							NeedRedstone: nrb,
+							LastOutput:         lo,
+							TickDelay:          tickdelay,
+							TrackOutput:        tob,
+							Conditional:        conb,
+							NeedRedstone:       nrb,
 						}
 						//fmt.Printf("%#v\n",cbdata)
-					}else{
-						pnd, hasNBT:=item["__tag"]
+					} else {
+						pnd, hasNBT := item["__tag"]
 						if hasNBT {
-							nbtData=[]byte(pnd.(string))
+							nbtData = []byte(pnd.(string))
 						}
 					}
-					lb:=chunk.RuntimeIDToLegacyBlock(runtimeId)
-					blocks[counter]=&types.Module {
-						Block: &types.Block {
+					lb := chunk.RuntimeIDToLegacyBlock(runtimeId)
+					blocks[counter] = &types.Module{
+						Block: &types.Block{
 							Name: &lb.Name,
 							Data: uint16(lb.Val),
 						},
 						CommandBlockData: cbdata,
-						ChestData: chestData,
-						NBTData: nbtData,
-						Point: types.Position {
+						ChestData:        chestData,
+						NBTData:          nbtData,
+						Point: types.Position{
 							X: x,
 							Y: y,
 							Z: z,
@@ -445,272 +357,26 @@ func CreateExportTask(commandLine string, env *environment.PBEnvironment) *task.
 				}
 			}
 		}
-		blocks=blocks[:counter]
+		blocks = blocks[:counter]
 		runtime.GC()
-		out:=bdump.BDumpLegacy {
+		out := bdump.BDumpLegacy{
 			Blocks: blocks,
 		}
-		if(strings.LastIndex(cfg.Path,".bdx")!=len(cfg.Path)-4||len(cfg.Path)<4) {
-			cfg.Path+=".bdx"
+		if strings.LastIndex(cfg.Path, ".bdx") != len(cfg.Path)-4 || len(cfg.Path) < 4 {
+			cfg.Path += ".bdx"
 		}
 		cmdsender.Output("EXPORT >> Writing output file")
-		err, signerr:=out.WriteToFile(cfg.Path, env.LocalCert, env.LocalKey)
-		if(err!=nil){
-			cmdsender.Output(fmt.Sprintf("EXPORT >> ERROR: Failed to export: %v",err))
+		err, signerr := out.WriteToFile(cfg.Path, env.LocalCert, env.LocalKey)
+		if err != nil {
+			cmdsender.Output(fmt.Sprintf("EXPORT >> ERROR: Failed to export: %v", err))
 			return
-		}else if(signerr!=nil) {
-			cmdsender.Output(fmt.Sprintf("EXPORT >> Note: The file is unsigned since the following error was trapped: %v",signerr))
-		}else{
+		} else if signerr != nil {
+			cmdsender.Output(fmt.Sprintf("EXPORT >> Note: The file is unsigned since the following error was trapped: %v", signerr))
+		} else {
 			cmdsender.Output(fmt.Sprintf("EXPORT >> File signed successfully"))
 		}
-		cmdsender.Output(fmt.Sprintf("EXPORT >> Successfully exported your structure to %v",cfg.Path))
+		cmdsender.Output(fmt.Sprintf("EXPORT >> Successfully exported your structure to %v", cfg.Path))
 		runtime.GC()
-	} ()
+	}()
 	return nil
 }
-
-func CreateLegacyExportTask(commandLine string, env *environment.PBEnvironment) *task.Task {
-	cfg, err := parsing.Parse(commandLine, configuration.GlobalFullConfig(env).Main())
-	if err!=nil {
-		env.CommandSender.Output(fmt.Sprintf("Failed to parse command: %v", err))
-		return nil
-	}
-	
-	beginPos := cfg.Position
-	endPos   := cfg.End
-	msizex:=0
-	msizey:=0
-	msizez:=0
-	if(endPos.X-beginPos.X<0) {
-		temp:=endPos.X
-		endPos.X=beginPos.X
-		beginPos.X=temp
-	}
-	msizex=endPos.X-beginPos.X+1
-	if(endPos.Y-beginPos.Y<0) {
-		temp:=endPos.Y
-		endPos.Y=beginPos.Y
-		beginPos.Y=temp
-	}
-	msizey=endPos.Y-beginPos.Y+1
-	if(endPos.Z-beginPos.Z<0) {
-		temp:=endPos.Z
-		endPos.Z=beginPos.Z
-		beginPos.Z=temp
-	}
-	msizez=endPos.Z-beginPos.Z+1
-	gsizez:=msizez
-	go func() {
-		u_d, _ := uuid.NewUUID()
-		env.CommandSender.SendWSCommand("gamemode c", u_d)
-		originx:=0
-		originz:=0
-		var blocks []*types.Module
-		for {
-			env.CommandSender.Output("EXPORT >> Fetching data")
-			cursizex:=msizex
-			cursizez:=msizez
-			if msizex>100 {
-				cursizex=100
-			}
-			if msizez>100 {
-				cursizez=100
-			}
-			posx:=beginPos.X+originx*100
-			posz:=beginPos.Z+originz*100
-			u_d2, _ := uuid.NewUUID()
-			wchan:=make(chan *packet.CommandOutput)
-			(*env.CommandSender.GetUUIDMap()).Store(u_d2.String(),wchan)
-			env.CommandSender.SendWSCommand(fmt.Sprintf("tp %d %d %d",posx,beginPos.Y+1,posz), u_d2)
-			<-wchan
-			close(wchan)
-			ExportWaiter=make(chan map[string]interface{})
-			env.Connection.(*minecraft.Conn).WritePacket(&packet.StructureTemplateDataRequest {
-				StructureName: "mystructure:a",
-				Position: protocol.BlockPos {int32(posx),int32(beginPos.Y),int32(posz)},
-				Settings: protocol.StructureSettings {
-					PaletteName: "default",
-					IgnoreEntities: true,
-					IgnoreBlocks: false,
-					Size: protocol.BlockPos {int32(cursizex),int32(msizey),int32(cursizez)},
-					Offset: protocol.BlockPos {0,0,0},
-					LastEditingPlayerUniqueID: env.Connection.(*minecraft.Conn).GameData().EntityUniqueID,
-					Rotation: 0,
-					Mirror: 0,
-					Integrity: 100,
-					Seed: 0,
-				},
-				RequestType: packet.StructureTemplateRequestExportFromSave,
-			})
-			exportData:=<-ExportWaiter
-			close(ExportWaiter)
-			env.CommandSender.Output("EXPORT >> Data received, processing.")
-			env.CommandSender.Output("EXPORT >> Extracting blocks")
-			sizeoo, _:=exportData["size"].([]interface{})
-			if len(sizeoo)==0 {
-				originz++
-				msizez-=cursizez
-				if(msizez<=0){
-					msizez=gsizez
-					originz=0
-					originx++
-					msizex-=cursizex
-				}
-				if(msizex<=0) {
-					break
-				}
-				continue
-			}
-			sizea,_:=sizeoo[0].(int32)
-			sizeb,_:=sizeoo[1].(int32)
-			sizec,_:=sizeoo[2].(int32)
-			size:=[]int{int(sizea),int(sizeb),int(sizec)}
-			structure, _:=exportData["structure"].(map[string]interface{})
-			indicesP, _:=structure["block_indices"].([]interface{})
-			indices,_:=indicesP[0].([]interface{})
-			if len(indicesP)!=2 {
-				panic(fmt.Errorf("Unexcepted indices data: %v\n",indices))
-			}
-			{
-				ind,_:=indices[0].(int32)
-				if ind==-1 {
-					indices,_=indicesP[1].([]interface{})
-				}
-				ind,_=indices[0].(int32)
-				if ind==-1 {
-					panic(fmt.Errorf("Exchanged but still -1: %v\n",indices))
-				}
-			}
-			blockpalettepar,_:=structure["palette"].(map[string]interface{})
-			blockpalettepar2,_:=blockpalettepar["default"].(map[string]interface{})
-			blockpalette,_:=blockpalettepar2["block_palette"].([]/*map[string]*/interface{})
-			blockposdata,_:=blockpalettepar2["block_position_data"].(map[string]interface{})
-			airind:=int32(-1)
-			i:=0
-			for x:=0;x<size[0];x++ {
-				for y:=0;y<size[1];y++ {
-					for z:=0;z<size[2];z++ {
-						ind,_:=indices[i].(int32)
-						if ind==-1 {
-							i++
-							continue
-						}
-						if ind==airind {
-							i++
-							continue
-						}
-						curblock,_:=blockpalette[ind].(map[string]interface{})
-						curblocknameunsplitted,_:=curblock["name"].(string)
-						curblocknamesplitted:=strings.Split(curblocknameunsplitted,":")
-						curblockname:=curblocknamesplitted[1]
-						var cbdata *types.CommandBlockData=nil
-						if curblockname=="air" {
-							i++
-							airind=ind
-							continue
-						}else if(!cfg.ExcludeCommands&&strings.Contains(curblockname,"command_block")) {
-							itemp,_:=blockposdata[strconv.Itoa(i)].(map[string]interface{})
-							item,_:=itemp["block_entity_data"].(map[string]interface{})
-							var mode uint32
-							if(curblockname=="command_block"){
-								mode=packet.CommandBlockImpulse
-							}else if(curblockname=="repeating_command_block"){
-								mode=packet.CommandBlockRepeating
-							}else if(curblockname=="chain_command_block"){
-								mode=packet.CommandBlockChain
-							}
-							cmd,_:=item["Command"].(string)
-							cusname,_:=item["CustomName"].(string)
-							exeft,_:=item["ExecuteOnFirstTick"].(uint8)
-							tickdelay,_:=item["TickDelay"].(int32)//*/
-							aut,_:=item["auto"].(uint8)//!needrestone
-							trackoutput,_:=item["TrackOutput"].(uint8)//
-							lo,_:=item["LastOutput"].(string)
-							conditionalmode:=item["conditionalMode"].(uint8)
-							var exeftb bool
-							if exeft==0 {
-								exeftb=false
-							}else{
-								exeftb=true
-							}
-							var tob bool
-							if trackoutput==1 {
-								tob=true
-							}else{
-								tob=false
-							}
-							var nrb bool
-							if aut==1 {
-								nrb=false
-								//REVERSED!!
-							}else{
-								nrb=true
-							}
-							var conb bool
-							if conditionalmode==1 {
-								conb=true
-							}else{
-								conb=false
-							}
-							cbdata=&types.CommandBlockData {
-								Mode: mode,
-								Command: cmd,
-								CustomName: cusname,
-								ExecuteOnFirstTick: exeftb,
-								LastOutput: lo,
-								TickDelay: tickdelay,
-								TrackOutput: tob,
-								Conditional: conb,
-								NeedRedstone: nrb,
-							}
-						}
-						curblockdata,_:=curblock["val"].(int16)
-						blocks=append(blocks,&types.Module{
-							Block: &types.Block {
-								Name:&curblockname,
-								Data:uint16(curblockdata),
-							},
-							CommandBlockData: cbdata,
-							Point: types.Position {
-								X: originx*100+x,
-								Y: y,
-								Z: originz*100+z,
-							},
-						})
-						i++
-					}
-				}
-			}
-			originz++
-			msizez-=cursizez
-			if(msizez<=0){
-				msizez=gsizez
-				originz=0
-				originx++
-				msizex-=cursizex
-			}
-			if(msizex<=0) {
-				break
-			}
-		}
-		out:=bdump.BDumpLegacy {
-			Blocks: blocks,
-		}
-		if(strings.LastIndex(cfg.Path,".bdx")!=len(cfg.Path)-4||len(cfg.Path)<4) {
-			cfg.Path+=".bdx"
-		}
-		env.CommandSender.Output("EXPORT >> Writing output file")
-		err, signerr:=out.WriteToFile(cfg.Path, env.LocalCert, env.LocalKey)
-		if(err!=nil){
-			env.CommandSender.Output(fmt.Sprintf("EXPORT >> ERROR: Failed to export: %v",err))
-			return
-		}else if(signerr!=nil) {
-			env.CommandSender.Output(fmt.Sprintf("EXPORT >> Note: The file is unsigned since the following error was trapped: %v",signerr))
-		}else{
-			env.CommandSender.Output(fmt.Sprintf("EXPORT >> File signed successfully"))
-		}
-		env.CommandSender.Output(fmt.Sprintf("EXPORT >> Successfully exported your structure to %v",cfg.Path))
-	} ()
-	return nil
-}
-

--- a/io/special_tasks/lexport.go
+++ b/io/special_tasks/lexport.go
@@ -1,0 +1,153 @@
+//go:build !is_tweak
+// +build !is_tweak
+
+package special_tasks
+
+import (
+	"fmt"
+	"phoenixbuilder/fastbuilder/bdump"
+	"phoenixbuilder/fastbuilder/configuration"
+	"phoenixbuilder/fastbuilder/environment"
+	"phoenixbuilder/fastbuilder/parsing"
+	"phoenixbuilder/fastbuilder/task"
+	"phoenixbuilder/io/special_tasks/lexport_depends"
+	"phoenixbuilder/minecraft"
+	"phoenixbuilder/minecraft/protocol"
+	"phoenixbuilder/minecraft/protocol/packet"
+	"runtime/debug"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/pterm/pterm"
+)
+
+func CreateLegacyExportTask(commandLine string, env *environment.PBEnvironment) *task.Task {
+	cfg, err := parsing.Parse(commandLine, configuration.GlobalFullConfig(env).Main())
+	if err != nil {
+		env.CommandSender.Output(pterm.Error.Sprintf("Failed to parse command: %v", err))
+		return nil
+	}
+	// 解析控制台输入
+	beginPos := cfg.Position
+	endPos := cfg.End
+	if beginPos.X > endPos.X {
+		save := beginPos.X
+		beginPos.X = endPos.X
+		endPos.X = save
+	}
+	if beginPos.Y > endPos.Y {
+		save := beginPos.Y
+		beginPos.Y = endPos.Y
+		endPos.Y = save
+	}
+	if beginPos.Z > endPos.Z {
+		save := beginPos.Z
+		beginPos.Z = endPos.Z
+		endPos.Z = save
+	}
+	// 取得起点坐标和终点坐标
+	go func() {
+		defer func() {
+			err := recover()
+			if err != nil {
+				debug.PrintStack()
+				env.CommandSender.Output(pterm.Error.Sprintf("go routine @ fastbuilder.task lexport crashed\n", err))
+			}
+		}()
+		// 当出现惊慌的时候不应该全部崩掉，而是尝试恢复其
+		u_d1, _ := uuid.NewUUID()
+		env.CommandSender.SendWSCommand("gamemode c", u_d1)
+		// 改创造
+		allAreasSplitAns, allAreasFindUse, useForProgress := lexport_depends.SplitArea(beginPos.X, beginPos.Y, beginPos.Z, endPos.X, endPos.Y, endPos.Z, 64, 64, true)
+		// 拆分目标导出区域为若干个小区域
+		// 每个小区域最大 64*64
+		allAreas := make([]lexport_depends.Mcstructure, 0)
+		for key, value := range allAreasSplitAns {
+			currentProgress := useForProgress[key]
+			env.CommandSender.Output(pterm.Info.Sprintf("Now Fetching data from area(relative to the starting point) [%v, %v]", currentProgress.Posx, currentProgress.Posz))
+			// 打印进度
+			u_d2, _ := uuid.NewUUID()
+			wchan := make(chan *packet.CommandOutput)
+			(*env.CommandSender.GetUUIDMap()).Store(u_d2.String(), wchan)
+			env.CommandSender.SendWSCommand(fmt.Sprintf("tp %d %d %d", value.BeginX, value.BeginY, value.BeginZ), u_d2)
+			<-wchan
+			close(wchan)
+			// 传送玩家
+			for {
+				u_d3, _ := uuid.NewUUID()
+				chann := make(chan *packet.CommandOutput)
+				(*env.CommandSender.GetUUIDMap()).Store(u_d3.String(), chann)
+				env.CommandSender.SendWSCommand(fmt.Sprintf("execute @a[name=\"%v\"] ~ ~ ~ testforblock ~ 2023 ~ air", env.Connection.(*minecraft.Conn).IdentityData().DisplayName), u_d3)
+				resp := <-chann
+				close(chann)
+				if resp.SuccessCount > 0 {
+					break
+				}
+			}
+			// 确认目标区域是否已经加载
+			ExportWaiter = make(chan map[string]interface{})
+			env.Connection.(*minecraft.Conn).WritePacket(&packet.StructureTemplateDataRequest{
+				StructureName: "PhoenixBuilder:LexportUsed",
+				Position:      protocol.BlockPos{int32(value.BeginX), int32(value.BeginY), int32(value.BeginZ)},
+				Settings: protocol.StructureSettings{
+					PaletteName:               "default",
+					IgnoreEntities:            true,
+					IgnoreBlocks:              false,
+					Size:                      protocol.BlockPos{int32(value.SizeX), int32(value.SizeY), int32(value.SizeZ)},
+					Offset:                    protocol.BlockPos{0, 0, 0},
+					LastEditingPlayerUniqueID: env.Connection.(*minecraft.Conn).GameData().EntityUniqueID,
+					Rotation:                  0,
+					Mirror:                    0,
+					Integrity:                 100,
+					Seed:                      0,
+				},
+				RequestType: packet.StructureTemplateRequestExportFromSave,
+			})
+			exportData := <-ExportWaiter
+			close(ExportWaiter)
+			// 获取 mcstructure
+			got, err := lexport_depends.GetMCStructureData(value, exportData)
+			if err != nil {
+				panic(err)
+			} else {
+				allAreas = append(allAreas, got)
+			}
+			// 添加数据
+		}
+		env.CommandSender.Output(pterm.Info.Sprint("Data received, processing......"))
+		env.CommandSender.Output(pterm.Info.Sprint("Extracting blocks......"))
+		// 打印进度
+		ans, err := lexport_depends.ExportBaseOnChunk(allAreas, allAreasFindUse, lexport_depends.Area{
+			BeginX: beginPos.X,
+			BeginY: beginPos.Y,
+			BeginZ: beginPos.Z,
+			SizeX:  endPos.X - beginPos.X + 1,
+			SizeY:  endPos.Y - beginPos.Y + 1,
+			SizeZ:  endPos.Z - beginPos.Z + 1,
+		})
+		if err != nil {
+			panic(err)
+		}
+		// 重排处理并写入方块数据
+		outputResult := bdump.BDumpLegacy{
+			Blocks: ans,
+		}
+		if strings.LastIndex(cfg.Path, ".bdx") != len(cfg.Path)-4 || len(cfg.Path) < 4 {
+			cfg.Path += ".bdx"
+		}
+		// 确定输出位置并封装结果
+		env.CommandSender.Output(pterm.Info.Sprint("Writing output file......"))
+		err, signerr := outputResult.WriteToFile(cfg.Path, env.LocalCert, env.LocalKey)
+		if err != nil {
+			env.CommandSender.Output(pterm.Error.Sprintf("Failed to export: %v", err))
+			return
+		} else if signerr != nil {
+			env.CommandSender.Output(pterm.Info.Sprintf("Note: The file is unsigned since the following error was trapped: %v", signerr))
+		} else {
+			env.CommandSender.Output(pterm.Success.Sprint("File signed successfully"))
+		}
+		env.CommandSender.Output(pterm.Success.Sprintf("Successfully exported your structure to %v", cfg.Path))
+		// 导出
+	}()
+	return nil
+}

--- a/io/special_tasks/lexport.go
+++ b/io/special_tasks/lexport.go
@@ -46,6 +46,13 @@ func CreateLegacyExportTask(commandLine string, env *environment.PBEnvironment) 
 		endPos.Z = save
 	}
 	// 取得起点坐标和终点坐标
+	if beginPos.Y < -64 {
+		beginPos.Y = -64
+	}
+	if endPos.Y > 320 {
+		endPos.Y = 320
+	}
+	// 虽然应该不会有人尝试超高度，不过我觉得还是要处理一下这个细节（
 	go func() {
 		defer func() {
 			err := recover()

--- a/io/special_tasks/lexport.go
+++ b/io/special_tasks/lexport.go
@@ -124,7 +124,7 @@ func CreateLegacyExportTask(commandLine string, env *environment.PBEnvironment) 
 		env.CommandSender.Output(pterm.Info.Sprint("Data received, processing......"))
 		env.CommandSender.Output(pterm.Info.Sprint("Extracting blocks......"))
 		// 打印进度
-		ans, err := lexport_depends.ExportBaseOnChunk(allAreas, allAreasFindUse, lexport_depends.Area{
+		ans, err := lexport_depends.ExportBaseOnChunkSize(allAreas, allAreasFindUse, lexport_depends.Area{
 			BeginX: beginPos.X,
 			BeginY: beginPos.Y,
 			BeginZ: beginPos.Z,

--- a/io/special_tasks/lexport_depends/TranslateNBTInterface/CommandBlock.go
+++ b/io/special_tasks/lexport_depends/TranslateNBTInterface/CommandBlock.go
@@ -1,0 +1,125 @@
+package TranslateNBTInerface
+
+import (
+	"fmt"
+	"phoenixbuilder/fastbuilder/types"
+)
+
+func GetCommandBlockData(cb map[string]interface{}, blockName string) (types.CommandBlockData, error) {
+	var normal bool = false
+	var command string = ""
+	var customName string = ""
+	var lastOutput string = ""
+	var mode int = 0
+	var tickDelay int32 = int32(0)
+	var executeOnFirstTick bool = true
+	var trackOutput bool = true
+	var conditionalMode bool = false
+	var needRedstone bool = true
+	// 初始化
+	_, ok := cb["Command"]
+	if ok {
+		command, normal = cb["Command"].(string)
+		if !normal {
+			return types.CommandBlockData{}, fmt.Errorf("Crashed in input[\"Command\"]")
+		}
+	}
+	// Command
+	_, ok = cb["CustomName"]
+	if ok {
+		customName, normal = cb["CustomName"].(string)
+		if !normal {
+			return types.CommandBlockData{}, fmt.Errorf("Crashed in input[\"CustomName\"]")
+		}
+	}
+	// CustomName
+	_, ok = cb["LastOutput"]
+	if ok {
+		lastOutput, normal = cb["LastOutput"].(string)
+		if !normal {
+			return types.CommandBlockData{}, fmt.Errorf("Crashed in input[\"LastOutput\"]")
+		}
+	}
+	// LastOutput
+	if blockName == "command_block" {
+		mode = 0
+	} else if blockName == "repeating_command_block" {
+		mode = 1
+	} else if blockName == "chain_command_block" {
+		mode = 2
+	} else {
+		return types.CommandBlockData{}, fmt.Errorf("Not a command block")
+	}
+	// mode
+	_, ok = cb["TickDelay"]
+	if ok {
+		tickDelay, normal = cb["TickDelay"].(int32)
+		if !normal {
+			return types.CommandBlockData{}, fmt.Errorf("Crashed in input[\"TickDelay\"]")
+		}
+	}
+	// TickDelay
+	_, ok = cb["ExecuteOnFirstTick"]
+	if ok {
+		got, normal := cb["ExecuteOnFirstTick"].(byte)
+		if !normal {
+			return types.CommandBlockData{}, fmt.Errorf("Crashed in input[\"ExecuteOnFirstTick\"]")
+		}
+		if got == byte(0) {
+			executeOnFirstTick = false
+		} else {
+			executeOnFirstTick = true
+		}
+	}
+	// ExecuteOnFirstTick
+	_, ok = cb["TrackOutput"]
+	if ok {
+		got, normal := cb["TrackOutput"].(byte)
+		if !normal {
+			return types.CommandBlockData{}, fmt.Errorf("Crashed in input[\"TrackOutput\"]")
+		}
+		if got == byte(0) {
+			trackOutput = false
+		} else {
+			trackOutput = true
+		}
+	}
+	// TrackOutput
+	_, ok = cb["conditionalMode"]
+	if ok {
+		got, normal := cb["conditionalMode"].(byte)
+		if !normal {
+			return types.CommandBlockData{}, fmt.Errorf("Crashed in input[\"conditionalMode\"]")
+		}
+		if got == byte(0) {
+			conditionalMode = false
+		} else {
+			conditionalMode = true
+		}
+	}
+	// Conditional
+	_, ok = cb["auto"]
+	if ok {
+		got, normal := cb["auto"].(byte)
+		if !normal {
+			return types.CommandBlockData{}, fmt.Errorf("Crashed in input[\"auto\"]")
+		}
+		if got == byte(0) {
+			needRedstone = true
+		} else {
+			needRedstone = false
+		}
+	}
+	// auto
+	return types.CommandBlockData{
+		Mode:               uint32(mode),
+		Command:            command,
+		CustomName:         customName,
+		LastOutput:         lastOutput,
+		TickDelay:          tickDelay,
+		ExecuteOnFirstTick: executeOnFirstTick,
+		TrackOutput:        trackOutput,
+		Conditional:        conditionalMode,
+		NeedRedstone:       needRedstone,
+	}, nil
+}

--- a/io/special_tasks/lexport_depends/TranslateNBTInterface/Container.go
+++ b/io/special_tasks/lexport_depends/TranslateNBTInterface/Container.go
@@ -1,0 +1,196 @@
+package TranslateNBTInerface
+
+import (
+	"fmt"
+	"phoenixbuilder/fastbuilder/types"
+)
+
+// 检查一个方块是否是有效的容器；这里的有效指的是可以被 replaceitem 命令生效的容器
+func CheckIfIsEffectiveContainer(name string) (string, error) {
+	index := map[string]string{
+		"blast_furnace":      "Items",
+		"lit_blast_furnace":  "Items",
+		"smoker":             "Items",
+		"lit_smoker":         "Items",
+		"furnace":            "Items",
+		"lit_furnace":        "Items",
+		"chest":              "Items",
+		"barrel":             "Items",
+		"trapped_chest":      "Items",
+		"lectern":            "book",
+		"hopper":             "Items",
+		"dispenser":          "Items",
+		"dropper":            "Items",
+		"cauldron":           "Items",
+		"lava_cauldron":      "Items",
+		"jukebox":            "RecordItem",
+		"brewing_stand":      "Items",
+		"undyed_shulker_box": "Items",
+		"shulker_box":        "Items",
+	}
+	value, ok := index[name]
+	if ok {
+		return value, nil
+	} else {
+		return "", fmt.Errorf("CheckIfIsEffectiveContainer: \"%v\" not found", name)
+	}
+}
+
+// 将 Interface NBT 转换为 types.ChestData
+func GetContainerData(container interface{}) (types.ChestData, error) {
+	var correct []interface{} = make([]interface{}, 0)
+	// 初始化
+	got, normal := container.([]interface{})
+	if !normal {
+		got, normal := container.(map[string]interface{})
+		if normal {
+			correct = append(correct, got)
+		} else {
+			return types.ChestData{}, fmt.Errorf("Crashed in input")
+		}
+	} else {
+		correct = got
+	}
+	// 把物品丢入 correct 里面
+	ans := make(types.ChestData, 0)
+	for key, value := range correct {
+		var count uint8 = uint8(0)
+		var itemData uint16 = uint16(0)
+		var name string = ""
+		var slot uint8 = uint8(0)
+		// 初始化
+		containerData, normal := value.(map[string]interface{})
+		if normal {
+			_, ok := containerData["Count"]
+			if ok {
+				got, normal := containerData["Count"].(byte)
+				if normal {
+					count = uint8(got)
+				} else {
+					return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"Count\"]", key)
+				}
+			} else {
+				return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"Count\"]", key)
+			}
+			// 物品数量
+			_, ok = containerData["Damage"]
+			if ok {
+				got, normal := containerData["Damage"].(int16)
+				if normal {
+					itemData = uint16(got)
+				} else {
+					return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"Damage\"]", key)
+				}
+			} else {
+				return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"Damage\"]", key)
+			}
+			_, ok = containerData["tag"]
+			if ok {
+				tag, normal := containerData["tag"].(map[string]interface{})
+				if normal {
+					_, ok = tag["Damage"]
+					if ok {
+						got, normal := tag["Damage"].(int32)
+						if normal {
+							itemData = uint16(got)
+						} else {
+							return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"tag\"]", key)
+						}
+					}
+				} else {
+					return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"tag\"]", key)
+				}
+			}
+			_, ok = containerData["Block"]
+			if ok {
+				Block, normal := containerData["Block"].(map[string]interface{})
+				if normal {
+					_, ok = Block["Block"]
+					if ok {
+						got, normal := Block["Block"].(map[string]interface{})
+						if normal {
+							_, ok = got["states"]
+							if ok {
+								states, normal := got["states"].(map[string]interface{})
+								if normal {
+									_, ok = states["val"]
+									if ok {
+										got, normal := states["val"].(int16)
+										if normal {
+											itemData = uint16(got)
+										} else {
+											return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"Block\"][\"states\"][\"val\"]", key)
+										}
+									} else {
+										return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"Block\"][\"states\"][\"val\"]", key)
+									}
+								} else {
+									return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"Block\"][\"states\"]", key)
+								}
+							} else {
+								return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"Block\"][\"states\"]", key)
+							}
+						} else {
+							return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"Block\"]", key)
+						}
+					}
+				} else {
+					return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"Block\"]", key)
+				}
+			}
+			// 物品数据值(附加值)
+			// 需要说明的是，数据值的获取优先级是这样的
+			// Damage < tag["Damage"] < Block["states"]["val"]
+			// 我目前还没有找到一种妥善的办法可以解决数据值的问题，所以我希望能有人帮帮我！
+			_, ok = containerData["Name"]
+			if ok {
+				got, normal := containerData["Name"].(string)
+				if normal {
+					name = got
+				} else {
+					return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"Name\"]", key)
+				}
+			} else {
+				return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"Name\"]", key)
+			}
+			// 物品名称
+			_, ok = containerData["Slot"]
+			if ok {
+				got, normal := containerData["Slot"].(byte)
+				if normal {
+					slot = uint8(got)
+				} else {
+					return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"Slot\"]", key)
+				}
+			}
+			// 物品所在的栏位
+			ans = append(ans, types.ChestSlot{
+				Name:   name,
+				Count:  count,
+				Damage: itemData,
+				Slot:   slot,
+			})
+		} else {
+			return types.ChestData{}, fmt.Errorf("Crashed in input[%v]", key)
+		}
+	}
+	return ans, nil
+}
+
+// 主函数
+func GetContainerDataRun(blockNBT map[string]interface{}, blockName string) (types.ChestData, error) {
+	key, err := CheckIfIsEffectiveContainer(blockName)
+	if err != nil {
+		return types.ChestData{}, fmt.Errorf("GetContainerDataRun: Not a container")
+	}
+	got, ok := blockNBT[key]
+	if ok {
+		ans, err := GetContainerData(got)
+		if err != nil {
+			return types.ChestData{}, fmt.Errorf("GetContainerData(Started by GetContainerDataRun): %v", err)
+		}
+		return ans, nil
+	} else {
+		return types.ChestData{}, nil
+	}
+}

--- a/io/special_tasks/lexport_depends/TranslateNBTInterface/Container.go
+++ b/io/special_tasks/lexport_depends/TranslateNBTInterface/Container.go
@@ -32,9 +32,8 @@ func CheckIfIsEffectiveContainer(name string) (string, error) {
 	value, ok := index[name]
 	if ok {
 		return value, nil
-	} else {
-		return "", fmt.Errorf("CheckIfIsEffectiveContainer: \"%v\" not found", name)
 	}
+	return "", fmt.Errorf("CheckIfIsEffectiveContainer: \"%v\" not found", name)
 }
 
 // 将 Interface NBT 转换为 types.ChestData
@@ -44,15 +43,17 @@ func GetContainerData(container interface{}) (types.ChestData, error) {
 	got, normal := container.([]interface{})
 	if !normal {
 		got, normal := container.(map[string]interface{})
-		if normal {
-			correct = append(correct, got)
-		} else {
+		if !normal {
 			return types.ChestData{}, fmt.Errorf("Crashed in input")
 		}
+		correct = append(correct, got)
 	} else {
 		correct = got
 	}
 	// 把物品丢入 correct 里面
+	// 如果这个物品是一个唱片机或者讲台，那么传入的 container 是一个 map[string]interface{} 而非 []interface{}
+	// 为了更好的兼容性(更加方便)，这里都会把 map[string]interface{} 处理成通常情况下的 []interface{}
+	// correct 就是处理结果
 	ans := make(types.ChestData, 0)
 	for key, value := range correct {
 		var count uint8 = uint8(0)
@@ -61,101 +62,112 @@ func GetContainerData(container interface{}) (types.ChestData, error) {
 		var slot uint8 = uint8(0)
 		// 初始化
 		containerData, normal := value.(map[string]interface{})
-		if normal {
-			_, ok := containerData["Count"]
-			if ok {
-				got, normal := containerData["Count"].(byte)
-				if normal {
-					count = uint8(got)
-				} else {
-					return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"Count\"]", key)
-				}
-			} else {
-				return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"Count\"]", key)
-			}
-			// 物品数量
-			_, ok = containerData["Damage"]
-			if ok {
-				got, normal := containerData["Damage"].(int16)
-				if normal {
-					itemData = uint16(got)
-				} else {
-					return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"Damage\"]", key)
-				}
-			} else {
-				return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"Damage\"]", key)
-			}
-			_, ok = containerData["tag"]
-			if ok {
-				tag, normal := containerData["tag"].(map[string]interface{})
-				if normal {
-					_, ok = tag["Damage"]
-					if ok {
-						got, normal := tag["Damage"].(int32)
-						if normal {
-							itemData = uint16(got)
-						} else {
-							return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"tag\"]", key)
-						}
-					}
-				} else {
-					return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"tag\"]", key)
-				}
-			}
-			_, ok = containerData["Block"]
-			if ok {
-				Block, normal := containerData["Block"].(map[string]interface{})
-				if normal {
-					_, ok = Block["val"]
-					if ok {
-						got, normal := Block["val"].(int16)
-						if normal {
-							itemData = uint16(got)
-						} else {
-							return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"Block\"][\"val\"]", key)
-						}
-					} else {
-						return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"Block\"][\"val\"]", key)
-					}
-				} else {
-					return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"Block\"]", key)
-				}
-			}
-			// 物品数据值(附加值)
-			// 需要说明的是，数据值的获取优先级是这样的
-			// Damage < tag["Damage"] < Block["val"]
-			// 我目前还没有找到一种妥善的办法可以解决数据值的问题，所以我希望能有人帮帮我！
-			_, ok = containerData["Name"]
-			if ok {
-				got, normal := containerData["Name"].(string)
-				if normal {
-					name = strings.Replace(got, "minecraft:", "", 1)
-				} else {
-					return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"Name\"]", key)
-				}
-			} else {
-				return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"Name\"]", key)
-			}
-			// 物品名称
-			_, ok = containerData["Slot"]
-			if ok {
-				got, normal := containerData["Slot"].(byte)
-				if normal {
-					slot = uint8(got)
-				} else {
-					return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"Slot\"]", key)
-				}
-			}
-			// 物品所在的栏位
-			ans = append(ans, types.ChestSlot{
-				Name:   name,
-				Count:  count,
-				Damage: itemData,
-				Slot:   slot,
-			})
-		} else {
+		if !normal {
 			return types.ChestData{}, fmt.Errorf("Crashed in input[%v]", key)
 		}
+		// correct 这个列表中的每一项都必须是一个复合标签，也就得是 map[string]interface{} 才行
+		_, ok := containerData["Count"]
+		if !ok {
+			return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"Count\"]", key)
+		}
+		count_got, normal := containerData["Count"].(byte)
+		if !normal {
+			return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"Count\"]", key)
+		}
+		count = uint8(count_got)
+		// 拿一下物品数量
+		// 这个物品数量是一定存在的，拿不到必须报错哦
+		_, ok = containerData["Damage"]
+		if !ok {
+			return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"Damage\"]", key)
+		}
+		damage_got, normal := containerData["Damage"].(int16)
+		if !normal {
+			return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"Damage\"]", key)
+		}
+		itemData = uint16(damage_got)
+		// 拿一下物品的 Damage 值
+		// 这里的 Damage 值不一定就是物品的数据值(附加值)
+		// 不过这个 Damage 值是一定存在的，拿不到必须报错哦
+		// 真的一定存在吗（？
+		_, ok = containerData["tag"]
+		if ok {
+			tag, normal := containerData["tag"].(map[string]interface{})
+			if !normal {
+				return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"tag\"]", key)
+			}
+			// 这个 input["tag"] 一定是一个复合标签，如果不是就必须报错哦
+			// 真的是吗（？
+			_, ok = tag["Damage"]
+			if ok {
+				got, normal := tag["Damage"].(int32)
+				if !normal {
+					return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"tag\"]", key)
+				}
+				itemData = uint16(got)
+			}
+		}
+		// 拿一下这个工具的耐久值（当然也可能是别的，甚至它都不是个工具）
+		// 这个 tag 里的 Damage 实际上也不一定就是物品的数据值(附加值)
+		// 需要说明的是，tag 不一定存在，且 tag 存在，Damage 也不一定存在
+		_, ok = containerData["Block"]
+		if ok {
+			Block, normal := containerData["Block"].(map[string]interface{})
+			if !normal {
+				return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"Block\"]", key)
+			}
+			// 这个 input["Block"] 一定是一个复合标签，如果不是就必须报错哦
+			// 如果 Block 找得到则说明这个物品是一个方块
+			_, ok = Block["val"]
+			if !ok {
+				return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"Block\"][\"val\"]", key)
+			}
+			got, normal := Block["val"].(int16)
+			if !normal {
+				return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"Block\"][\"val\"]", key)
+			}
+			itemData = uint16(got)
+			// 如果这个物品是个方块，也就是 Block 找得到的话
+			// 那在 Block 里面一定有一个 val 去声明这个方块的方块数据值(附加值)
+		}
+		// 拿一下这个方块的方块数据值(附加值)
+		// 这个 Block 里的 val 一定是这个物品对应的方块的方块数据值(附加值)
+		// 需要说明的是，Block 不一定存在，但如果 Block 存在，则 val 一定存在
+		// 除非网易尝试打击我们，把 val 扣掉了
+
+		// 以上三个都在拿物品数据值(附加值)
+		// 需要说明的是，数据值的获取优先级是这样的
+		// Damage < tag["Damage"] < Block["val"]
+		// 需要说明的是，以上列举的三个情况不能涵盖所有的物品数据值(附加值)的情况，所以我希望可以有个人看一下普世情况是长什么样的，请帮帮我！
+		_, ok = containerData["Name"]
+		if !ok {
+			return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"Name\"]", key)
+		}
+		got, normal := containerData["Name"].(string)
+		if !normal {
+			return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"Name\"]", key)
+		}
+		name = strings.Replace(got, "minecraft:", "", 1)
+		// 拿一下这个物品的物品名称
+		// 可以看到，我这里是把命名空间删了的
+		// 这个物品名称是一定存在的，拿不到必须报错哦
+		_, ok = containerData["Slot"]
+		if ok {
+			got, normal := containerData["Slot"].(byte)
+			if !normal {
+				return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"Slot\"]", key)
+			}
+			slot = uint8(got)
+		}
+		// 拿一下这个物品所在的栏位(槽位)
+		// 这个栏位(槽位)不一定存在，例如唱片机和讲台这种就不存在了(这种方块就一个物品，就不需要这个数据了)
+		ans = append(ans, types.ChestSlot{
+			Name:   name,
+			Count:  count,
+			Damage: itemData,
+			Slot:   slot,
+		})
+		// 提交数据
 	}
 	return ans, nil
 }
@@ -167,13 +179,16 @@ func GetContainerDataRun(blockNBT map[string]interface{}, blockName string) (typ
 		return types.ChestData{}, fmt.Errorf("GetContainerDataRun: Not a container")
 	}
 	got, ok := blockNBT[key]
+	// 这里是确定一下这个容器是否是我们支持了的容器
 	if ok {
 		ans, err := GetContainerData(got)
 		if err != nil {
 			return types.ChestData{}, fmt.Errorf("GetContainerData(Started by GetContainerDataRun): %v", err)
 		}
 		return ans, nil
-	} else {
-		return types.ChestData{}, nil
 	}
+	// 如果这是个容器且对应的 key 可以找到，那么就去拿一下对应的 types.ChestData 结构体
+	return types.ChestData{}, nil
+	// 对于唱片机和讲台这种容器，如果它们没有被放物品的话，那么对应的 key 是找不到的
+	// 但是这不是一个错误，所以我们返回一个空的 types.ChestData 和一个空的 error
 }

--- a/io/special_tasks/lexport_depends/TranslateNBTInterface/Container.go
+++ b/io/special_tasks/lexport_depends/TranslateNBTInterface/Container.go
@@ -106,34 +106,16 @@ func GetContainerData(container interface{}) (types.ChestData, error) {
 			if ok {
 				Block, normal := containerData["Block"].(map[string]interface{})
 				if normal {
-					_, ok = Block["Block"]
+					_, ok = Block["val"]
 					if ok {
-						got, normal := Block["Block"].(map[string]interface{})
+						got, normal := Block["val"].(int16)
 						if normal {
-							_, ok = got["states"]
-							if ok {
-								states, normal := got["states"].(map[string]interface{})
-								if normal {
-									_, ok = states["val"]
-									if ok {
-										got, normal := states["val"].(int16)
-										if normal {
-											itemData = uint16(got)
-										} else {
-											return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"Block\"][\"states\"][\"val\"]", key)
-										}
-									} else {
-										return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"Block\"][\"states\"][\"val\"]", key)
-									}
-								} else {
-									return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"Block\"][\"states\"]", key)
-								}
-							} else {
-								return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"Block\"][\"states\"]", key)
-							}
+							itemData = uint16(got)
 						} else {
-							return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"Block\"]", key)
+							return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"Block\"][\"val\"]", key)
 						}
+					} else {
+						return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"Block\"][\"val\"]", key)
 					}
 				} else {
 					return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"Block\"]", key)
@@ -141,7 +123,7 @@ func GetContainerData(container interface{}) (types.ChestData, error) {
 			}
 			// 物品数据值(附加值)
 			// 需要说明的是，数据值的获取优先级是这样的
-			// Damage < tag["Damage"] < Block["states"]["val"]
+			// Damage < tag["Damage"] < Block["val"]
 			// 我目前还没有找到一种妥善的办法可以解决数据值的问题，所以我希望能有人帮帮我！
 			_, ok = containerData["Name"]
 			if ok {

--- a/io/special_tasks/lexport_depends/TranslateNBTInterface/Container.go
+++ b/io/special_tasks/lexport_depends/TranslateNBTInterface/Container.go
@@ -3,6 +3,7 @@ package TranslateNBTInerface
 import (
 	"fmt"
 	"phoenixbuilder/fastbuilder/types"
+	"strings"
 )
 
 // 检查一个方块是否是有效的容器；这里的有效指的是可以被 replaceitem 命令生效的容器
@@ -146,7 +147,7 @@ func GetContainerData(container interface{}) (types.ChestData, error) {
 			if ok {
 				got, normal := containerData["Name"].(string)
 				if normal {
-					name = got
+					name = strings.Replace(got, "minecraft:", "", 1)
 				} else {
 					return types.ChestData{}, fmt.Errorf("Crashed in input[%v][\"Name\"]", key)
 				}

--- a/io/special_tasks/lexport_depends/TranslateNBTInterface/NBTInterfaceToString.go
+++ b/io/special_tasks/lexport_depends/TranslateNBTInterface/NBTInterfaceToString.go
@@ -1,0 +1,156 @@
+package TranslateNBTInerface
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// 判断 nbt 中 value 的数据类型
+func GetData(input interface{}) (string, error) {
+	value1, result := input.(byte)
+	if result {
+		return fmt.Sprintf("%vb", int(value1)), nil
+	}
+	// byte
+	value2, result := input.(int16)
+	if result {
+		return fmt.Sprintf("%vs", value2), nil
+	}
+	// short
+	value3, result := input.(int32)
+	if result {
+		return fmt.Sprintf("%v", value3), nil
+	}
+	// int
+	value4, result := input.(int64)
+	if result {
+		return fmt.Sprintf("%vl", value4), nil
+	}
+	// long
+	value5, result := input.(float32)
+	if result {
+		return fmt.Sprintf("%vf", strconv.FormatFloat(float64(value5), 'f', 16, 32)), nil
+	}
+	// float
+	value6, result := input.(float64)
+	if result {
+		return fmt.Sprintf("%vd", strconv.FormatFloat(float64(value6), 'f', 16, 64)), nil
+	}
+	// double
+	value, result := input.([]interface{})
+	if result {
+		if len(value) > 0 {
+			_, result = value[0].(byte)
+			if result {
+				ans := make([]string, 0)
+				for _, i := range value {
+					got, err := i.(byte)
+					if err {
+						ans = append(ans, fmt.Sprintf("%vb", int(got)))
+					} else {
+						return "", fmt.Errorf("GetData: Failed")
+					}
+				}
+				return fmt.Sprintf("[B; %v]", strings.Join(ans, ", ")), nil
+			}
+			// byte_array
+			_, result = value[0].(int32)
+			if result {
+				ans := make([]string, 0)
+				for _, i := range value {
+					got, err := i.(int32)
+					if err {
+						ans = append(ans, fmt.Sprintf("%v", got))
+					} else {
+						return "", fmt.Errorf("GetData: Failed")
+					}
+				}
+				return fmt.Sprintf("[I; %v]", strings.Join(ans, ", ")), nil
+			}
+			// int_array
+			_, result = value[0].(int64)
+			if result {
+				ans := make([]string, 0)
+				for _, i := range value {
+					got, err := i.(int64)
+					if err {
+						ans = append(ans, fmt.Sprintf("%v", got))
+					} else {
+						return "", fmt.Errorf("GetData: Failed")
+					}
+				}
+				return fmt.Sprintf("[L; %v]", strings.Join(ans, ", ")), nil
+			}
+			// long_array
+		}
+		got, err := List(value)
+		if err != nil {
+			return "", fmt.Errorf("GetData: Failed")
+		} else {
+			return got, nil
+		}
+		// list
+	}
+	// byte_array, int_array, long_array, list
+	value7, result := input.(string)
+	if result {
+		return fmt.Sprintf("\"%v\"", value7), nil
+	}
+	// string
+	value8, result := input.(map[string]interface{})
+	if result {
+		compound, err := Compound(value8, false)
+		if err != nil {
+			return "", fmt.Errorf("GetData: Failed")
+		} else {
+			return compound, nil
+		}
+	}
+	// compound
+	return "", fmt.Errorf("GetData: Failed")
+}
+
+func Compound(input map[string]interface{}, outputBlockStatesMode bool) (string, error) {
+	ans := make([]string, 0)
+	for key, value := range input {
+		if value == nil {
+			return "", fmt.Errorf("Compound: Crashed in input[\"%v\"]", key)
+		}
+		got, err := GetData(value)
+		if err != nil {
+			return "", fmt.Errorf("Compound: Crashed in input[\"%v\"]", key)
+		} else {
+			if got[len(got)-1] == "b"[0] && outputBlockStatesMode {
+				if got == "0b" {
+					got = "false"
+				} else if got == "1b" {
+					got = "true"
+				} else {
+					return "", fmt.Errorf("Compound: Crashed in input[\"%v\"]", key)
+				}
+			}
+			ans = append(ans, fmt.Sprintf("\"%v\": %v", key, got))
+		}
+	}
+	if outputBlockStatesMode {
+		return fmt.Sprintf("[%v]", strings.Join(ans, ", ")), nil
+	}
+	return fmt.Sprintf("{%v}", strings.Join(ans, ", ")), nil
+}
+
+func List(input []interface{}) (string, error) {
+	ans := make([]string, 0)
+	for key, value := range input {
+		if value == nil {
+			return "", fmt.Errorf("List: Crashed in input[\"%v\"]", key)
+		}
+		got, err := GetData(value)
+		if err != nil {
+			return "", fmt.Errorf("List: Crashed in input[\"%v\"]", key)
+		} else {
+			ans = append(ans, got)
+		}
+	}
+	return fmt.Sprintf("[%v]", strings.Join(ans, ", ")), nil
+}

--- a/io/special_tasks/lexport_depends/main.go
+++ b/io/special_tasks/lexport_depends/main.go
@@ -1,0 +1,563 @@
+package lexport_depends
+
+import (
+	"fmt"
+	"math"
+	"phoenixbuilder/fastbuilder/types"
+	TranslateNBTInerface "phoenixbuilder/io/special_tasks/lexport_depends/TranslateNBTInterface"
+	"strconv"
+	"strings"
+)
+
+// 用于描述一个区域的基本信息，也就是区域的起点位置及区域的尺寸
+type Area struct {
+	BeginX int
+	BeginY int
+	BeginZ int
+	SizeX  int
+	SizeY  int
+	SizeZ  int
+}
+
+// 用于描述一个区域的坐标
+type AreaLocation struct {
+	Posx int
+	Posz int
+}
+
+// 用于描述一个方块的坐标
+type BlockPos struct {
+	Posx int
+	Posy int
+	Posz int
+}
+
+/*
+用于存放一个 MCBE 的结构；这里面的数据稍微作了一些处理，只保留了需要的部分
+
+如果后期要给这个结构体添加别的东西，请参见本文件中的 GetMCStructureData 函数
+*/
+type Mcstructure struct {
+	info                     Area                           // 用于描述这个结构的基本信息，也就是起点位置及尺寸
+	blockPalette             []string                       // 用于存放调色板(方块池)中的方块名
+	blockPalette_blockStates []string                       // 用于存放调色板(方块池)中的数据；这里的方块池稍作了处理，只保留了方块状态(string)，且这种方块状态正是 setblock 命令所需要的部分；需要特别说明的是，方块状态里面所有的 TAG_Byte 都被处理成了布尔值，如果有 BUG 记得提 Issue
+	blockPalette_blockData   []int16                        // 用于存放调色板(方块池)中的数据；这里的方块池稍作了处理，只保留了方块数据值，也就是附加值(int)；这个东西只是为了支持容器而做的
+	foreground               []int16                        // 用于描述一个方块的前景层；这里应该用 int32 的，不过 PhoenixBuilder 只能表示 int16 个方块，所以我这里就省一下内存
+	background               []int16                        // 用于描述一个方块的背景层；这里应该用 int32 的，不过 PhoenixBuilder 只能表示 int16 个方块，所以我这里就省一下内存
+	blockNBT                 map[int]map[string]interface{} // 用于存放方块实体数据
+}
+
+/*
+用于拆分一个大区域为若干个小区域；当 useSpecialSplitWay 为真时，将蛇形拆分区域
+
+返回值 []Area 代表一个已经排好顺序的若干个小区域
+
+返回值 map[AreaLocation]int 代表可以通过 区域坐标(AreaLocation) 来访问 []Area 的对应项
+
+因此，返回值 map[int]AreaLocation 是返回值 map[AreaLocation]int 的逆过程
+*/
+func SplitArea(
+	startX int, startY int, startZ int,
+	endX int, endY int, endZ int,
+	splitSizeX int, splitSizeZ int,
+	useSpecialSplitWay bool,
+) ([]Area, map[AreaLocation]int, map[int]AreaLocation) {
+	if splitSizeX < 0 {
+		splitSizeX = splitSizeX * -1
+	}
+	if splitSizeZ < 0 {
+		splitSizeZ = splitSizeZ * -1
+	}
+	// 考虑一些特殊的情况，此举是为了更高的兼容性
+	var save int
+	if endX < startX {
+		save = startX
+		startX = endX
+		endX = save
+	}
+	if endY < startY {
+		save = startY
+		startY = endY
+		endY = save
+	}
+	if endZ < startZ {
+		save = startZ
+		startZ = endZ
+		endZ = save
+	}
+	// 考虑一些特殊的情况，此举是为了更高的兼容性
+	sizeX := endX - startX + 1
+	sizeY := endY - startY + 1
+	sizeZ := endZ - startZ + 1
+	// 取得 Area 的大小
+	chunkX_length := int(math.Ceil(float64(sizeX) / float64(splitSizeX)))
+	chunkZ_length := int(math.Ceil(float64(sizeZ) / float64(splitSizeZ)))
+	// 取得各轴上需要拆分的区域数
+	ans := make([]Area, chunkX_length*chunkZ_length) // 这个东西最终会 return 掉
+	areaLoctionToInt := map[AreaLocation]int{}       // 知道了区域的坐标求区域在 []Area 的位置
+	IntToareaLoction := map[int]AreaLocation{}       // 知道了区域在 []Area 的位置求区域坐标
+	facing := -1                                     // 蛇形处理的时候需要用到这个
+	key := -1                                        // 向 ans 插入数据的时候需要用到这个
+	// 初始化
+	for chunkX := 1; chunkX <= chunkX_length; chunkX++ {
+		facing = facing * -1
+		BeginX := splitSizeX*(chunkX-1) + startX
+		xLength := splitSizeX
+		if BeginX+xLength-1 > endX {
+			xLength = endX - BeginX + 1
+		}
+		for chunkZ := 1; chunkZ <= chunkZ_length; chunkZ++ {
+			key++ // p = p + 1
+			currentChunkZ := chunkZ
+			if useSpecialSplitWay && facing == -1 {
+				currentChunkZ = chunkZ_length - currentChunkZ + 1
+			}
+			BeginZ := splitSizeZ*(currentChunkZ-1) + startZ
+			zLength := splitSizeZ
+			if BeginZ+zLength-1 > endZ {
+				zLength = endZ - BeginZ + 1
+			}
+			ans[key] = Area{
+				BeginX: BeginX,
+				BeginY: startY,
+				BeginZ: BeginZ,
+				SizeX:  xLength,
+				SizeY:  sizeY,
+				SizeZ:  zLength,
+			}
+			areaLoctionToInt[AreaLocation{chunkX - 1, currentChunkZ - 1}] = key
+			IntToareaLoction[key] = AreaLocation{chunkX - 1, currentChunkZ - 1}
+		}
+	}
+	return ans, areaLoctionToInt, IntToareaLoction
+}
+
+// 用于提取得到的 MCBE 结构文件中的一些数据，具体拿了什么数据，你可以看返回值字段
+func GetMCStructureData(area Area, structure map[string]interface{}) (Mcstructure, error) {
+	var value_default map[string]interface{} = map[string]interface{}{}
+	var ok bool = false
+	var normal = false
+
+	var value_structure map[string]interface{} = map[string]interface{}{}
+
+	var blockPalette = []string{}
+	var blockPalette_blockStates []string = []string{}
+	var blockPalette_blockData []int16 = []int16{}
+	var blockNBT map[int]map[string]interface{} = map[int]map[string]interface{}{}
+	var foreground []int16 = []int16{}
+	var background []int16 = []int16{}
+	// 初始化
+	_, ok = structure["structure"]
+	if ok {
+		value_structure, normal = structure["structure"].(map[string]interface{})
+		if normal {
+			_, ok = value_structure["palette"]
+			if ok {
+				value_palette, normal := value_structure["palette"].(map[string]interface{})
+				if normal {
+					_, ok = value_palette["default"]
+					if ok {
+						value_default, normal = value_palette["default"].(map[string]interface{})
+						if normal {
+							_, ok = value_default["block_palette"]
+							if ok {
+								value_block_palette, normal := value_default["block_palette"].([]interface{})
+								if normal {
+									for key, value := range value_block_palette {
+										got, normal := value.(map[string]interface{})
+										if normal {
+											_, ok = got["name"]
+											if ok {
+												value_name, normal := got["name"].(string)
+												if normal {
+													blockPalette = append(blockPalette, value_name)
+												} else {
+													return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"palette\"][\"default\"][\"block_palette\"][%v][\"name\"]", key)
+												}
+											} else {
+												return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"palette\"][\"default\"][\"block_palette\"][%v][\"name\"]", key)
+											}
+											// get block name
+											_, ok = got["states"]
+											if ok {
+												value_states, normal := got["states"].(map[string]interface{})
+												if normal {
+													blockStates, err := TranslateNBTInerface.Compound(value_states, true)
+													if err != nil {
+														return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"palette\"][\"default\"][\"block_palette\"][%v][\"states\"]", key)
+													} else {
+														blockPalette_blockStates = append(blockPalette_blockStates, blockStates)
+													}
+												} else {
+													return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"palette\"][\"default\"][\"block_palette\"][%v][\"states\"]", key)
+												}
+											} else {
+												return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"palette\"][\"default\"][\"block_palette\"][%v]", key)
+											}
+											// get block states
+											_, ok = got["val"]
+											if ok {
+												val, normal := got["val"].(int16)
+												if normal {
+													blockPalette_blockData = append(blockPalette_blockData, val)
+												} else {
+													return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"palette\"][\"default\"][\"block_palette\"][%v][\"val\"]", key)
+												}
+											} else {
+												return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"palette\"][\"default\"][\"block_palette\"][%v][\"val\"]", key)
+											}
+											// get block data
+										} else {
+											return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"palette\"][\"default\"][\"block_palette\"][%v]", key)
+										}
+									}
+								} else {
+									return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"palette\"][\"default\"][\"block_palette\"]")
+								}
+							} else {
+								return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"palette\"][\"default\"][\"block_palette\"]")
+							}
+						} else {
+							return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"palette\"][\"default\"]")
+						}
+					} else {
+						return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"palette\"][\"default\"]")
+					}
+				} else {
+					return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"palette\"]")
+				}
+			}
+		} else {
+			return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"]")
+		}
+	} else {
+		return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"]")
+	}
+	// 先把方块状态得到，放于列表 blockPalette 中
+	// 很抱歉，我写出了金字塔屎山（
+	_, ok = value_default["block_position_data"]
+	if ok {
+		value_block_position_data, normal := value_default["block_position_data"].(map[string]interface{})
+		if normal {
+			for key, value := range value_block_position_data {
+				block_position_data, ok := value.(map[string]interface{})
+				if ok {
+					location_of_block_position_data, err := strconv.ParseInt(key, 10, 64)
+					if err != nil {
+						return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"default\"][\"block_position_data\"][%v]", key)
+					}
+					if blockNBT[int(location_of_block_position_data)] == nil {
+						blockNBT[int(location_of_block_position_data)] = make(map[string]interface{})
+					}
+					blockNBT[int(location_of_block_position_data)] = map[string]interface{}{"block_position_data": block_position_data}
+				} else {
+					return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"default\"][\"block_position_data\"][%v]", key)
+				}
+			}
+		} else {
+			return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"default\"][\"block_position_data\"]")
+		}
+	}
+	// 众所不一定周知，这个方块实体数据可能是不存在的(当然这个我没测试过)
+	// 然后找到所有的方块实体数据，放于 map(blockNBT) 中
+	_, ok = value_structure["block_indices"]
+	if ok {
+		value_block_indices, normal := value_structure["block_indices"].([]interface{})
+		if normal {
+			if len(value_block_indices) == 2 {
+				value_block_indices_0, normal := value_block_indices[0].([]interface{})
+				if normal {
+					for blockLocation_key, blockLocation := range value_block_indices_0 {
+						got, normal := blockLocation.(int32)
+						if normal {
+							foreground = append(foreground, int16(got))
+						} else {
+							return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"block_indices\"][0][%v]", blockLocation_key)
+						}
+					}
+				} else {
+					return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"block_indices\"][0]")
+				}
+				value_block_indices_1, normal := value_block_indices[1].([]interface{})
+				if normal {
+					for blockLocation_key, blockLocation := range value_block_indices_1 {
+						got, normal := blockLocation.(int32)
+						if normal {
+							background = append(background, int16(got))
+						} else {
+							return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"block_indices\"][1][%v]", blockLocation_key)
+						}
+					}
+				} else {
+					return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"block_indices\"][1]")
+				}
+			} else {
+				return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"block_indices\"]")
+			}
+		} else {
+			return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"block_indices\"]")
+		}
+	} else {
+		return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"block_indices\"]")
+	}
+	// 然后分别拿到方块池的前景层和背景层
+	return Mcstructure{
+		info:                     area,
+		blockPalette:             blockPalette,
+		blockPalette_blockStates: blockPalette_blockStates,
+		blockPalette_blockData:   blockPalette_blockData,
+		foreground:               foreground,
+		background:               background,
+		blockNBT:                 blockNBT,
+	}, nil
+}
+
+// 根据 mcstructure 的起点和尺寸，以及提供的方块坐标，寻找这个方块在 mcstructure 中的角标
+func SearchForBlock(structureInfo Area, pos BlockPos) (int, error) {
+	pos.Posx = pos.Posx - structureInfo.BeginX
+	pos.Posy = pos.Posy - structureInfo.BeginY
+	pos.Posz = pos.Posz - structureInfo.BeginZ
+	// 将方块的绝对坐标转换为相对坐标(相对于 mcstructure)
+	blockCount := structureInfo.SizeX * structureInfo.SizeY * structureInfo.SizeZ
+	// 计算结构的尺寸
+	angleMark := 0
+	angleMark = angleMark + structureInfo.SizeY*structureInfo.SizeZ*pos.Posx
+	angleMark = angleMark + structureInfo.SizeZ*pos.Posy
+	angleMark = angleMark + pos.Posz
+	// 计算方块相对于 mcstructure 的角标
+	if angleMark > blockCount-1 {
+		return -1, fmt.Errorf("Index out of the list, occured in input[%v]", angleMark)
+	}
+	return angleMark, nil
+}
+
+func ExportBaseOnChunk(
+	allAreas []Mcstructure,
+	allAreasFindUse map[AreaLocation]int,
+	currentExport Area,
+) ([]*types.Module, error) {
+	ans := make([]*types.Module, 0)
+	// 这个东西最后会 return 掉
+	allChunks, _, allChunksFindUse := SplitArea(
+		currentExport.BeginX, currentExport.BeginY, currentExport.BeginZ,
+		currentExport.BeginX+currentExport.SizeX-1,
+		currentExport.BeginY+currentExport.SizeY-1,
+		currentExport.BeginZ+currentExport.SizeZ-1,
+		16, 16, true,
+	)
+	// 将所有待导出区域按 16*16 的大小拆分为区块，且蛇形拆分
+	// 然后按照得到的结果重排处理
+	for key, value := range allChunks {
+		chunkPos := allChunksFindUse[key]
+		chunkPos.Posx = int(math.Floor(float64(chunkPos.Posx) / 4))
+		chunkPos.Posz = int(math.Floor(float64(chunkPos.Posz) / 4))
+		// 取得当前遍历的区块的坐标
+		// 这里已经把坐标变换到 allAreas 下的坐标系中
+		targetAreaPos := allAreasFindUse[chunkPos]
+		targetArea := allAreas[targetAreaPos]
+		// 取得被遍历区块对应的 mcstructure
+		i, _, _ := SplitArea(
+			value.BeginX, value.BeginY, value.BeginZ,
+			value.BeginX+value.SizeX-1,
+			value.BeginY+value.SizeY-1,
+			value.BeginZ+value.SizeZ-1,
+			1, 1, true,
+		)
+		allBlocksInCurrentChunk := make([]int32, 0)
+		for _, VALUE := range i {
+			got, err := SearchForBlock(targetArea.info, BlockPos{
+				Posx: VALUE.BeginX,
+				Posy: VALUE.BeginY,
+				Posz: VALUE.BeginZ,
+			})
+			if err != nil {
+				return []*types.Module{}, fmt.Errorf("SearchForBlock(Started by ExportBaseOnChunk): %v", err)
+			}
+			allBlocksInCurrentChunk = append(allBlocksInCurrentChunk, int32(got))
+		}
+		// 枚举出被遍历区块中所有方块的坐标(只枚举其中一层)
+		for KEY, VALUE := range allBlocksInCurrentChunk {
+			VALUE = VALUE - int32(targetArea.info.SizeZ)
+			// 这个前置处理方法可能不太优雅
+			// 凑合着用吧
+			for j := 0; j < targetArea.info.SizeY; j++ {
+				VALUE = VALUE + int32(targetArea.info.SizeZ)
+				// 前往下一层
+				foreground_blockName := "undefined"
+				background_blockName := "undefined"
+				foreground_blockStates := "undefined"
+				background_blockStates := "undefined"
+				foreground_blockData := int16(-1)
+				// 初始化
+				fgId := targetArea.foreground[VALUE] // 前景层方块在调色板中的id
+				bgId := targetArea.background[VALUE] // 背景层方块在调色板中的id
+				if fgId != -1 {
+					foreground_blockName = strings.Replace(targetArea.blockPalette[fgId], "minecraft:", "", 1) // 前景层方块的名称
+					foreground_blockStates = targetArea.blockPalette_blockStates[fgId]                         // 前景层方块的方块状态
+					foreground_blockData = targetArea.blockPalette_blockData[fgId]                             // 前景层方块的方块数据值(附加值)
+				}
+				if bgId != -1 {
+					background_blockName = strings.Replace(targetArea.blockPalette[bgId], "minecraft:", "", 1) // 背景层方块的名称
+					background_blockStates = targetArea.blockPalette_blockStates[bgId]                         // 背景层方块的方块状态
+				}
+				// 获得基本信息
+				var hasNBT bool = false
+				var containerDataMark bool = false
+				var containerData types.ChestData = types.ChestData{}
+				var commandBlockDataMark bool = false
+				var commandBlockData types.CommandBlockData = types.CommandBlockData{}
+				var string_nbt string = ""
+				var err error = fmt.Errorf("")
+
+				got, ok := targetArea.blockNBT[int(VALUE)]
+				if ok {
+					_, ok := got["block_position_data"]
+					if ok {
+						block_position_data, normal := got["block_position_data"].(map[string]interface{})
+						if normal {
+							_, ok := block_position_data["block_entity_data"]
+							if ok {
+								block_entity_data, normal := block_position_data["block_entity_data"].(map[string]interface{})
+								if normal {
+									containerData, err = TranslateNBTInerface.GetContainerDataRun(block_entity_data, foreground_blockName)
+									if fmt.Sprintf("%v", err) != "GetContainerDataRun: Not a container" && err != nil {
+										return []*types.Module{}, fmt.Errorf("%v", err)
+									} else if err == nil {
+										if foreground_blockName == "chest" {
+											useOfChest := "trapped_chest"
+											ans = append(ans, &types.Module{
+												Block: &types.Block{
+													Name: &useOfChest,
+													Data: 0,
+												},
+												Point: types.Position{
+													X: i[KEY].BeginX - currentExport.BeginX,
+													Y: i[KEY].BeginY + j - currentExport.BeginY,
+													Z: i[KEY].BeginZ - currentExport.BeginZ,
+												},
+											})
+										}
+										// 这么处理是为了解决箱子间的连接问题，让所有的箱子都不再连接
+										if foreground_blockName == "trapped_chest" {
+											useOfChest := "chest"
+											ans = append(ans, &types.Module{
+												Block: &types.Block{
+													Name: &useOfChest,
+													Data: 0,
+												},
+												Point: types.Position{
+													X: i[KEY].BeginX - currentExport.BeginX,
+													Y: i[KEY].BeginY + j - currentExport.BeginY,
+													Z: i[KEY].BeginZ - currentExport.BeginZ,
+												},
+											})
+										}
+										// 这么处理是为了解决箱子间的连接问题，让所有的箱子都不再连接
+										containerDataMark = true
+									}
+									// 容器
+									if foreground_blockName == "command_block" || foreground_blockName == "repeating_command_block" || foreground_blockName == "chain_command_block" {
+										commandBlockData, err = TranslateNBTInerface.GetCommandBlockData(block_entity_data, foreground_blockName)
+										if err != nil {
+											return []*types.Module{}, fmt.Errorf("GetCommandBlockData(Started by ExportBaseOnChunk): %v", err)
+										}
+										commandBlockDataMark = true
+									}
+									// 命令方块
+									hasNBT = true
+									string_nbt, err = TranslateNBTInerface.Compound(block_entity_data, false)
+									string_nbt = fmt.Sprintf("{\"block_entity_data\": %v}", string_nbt)
+									if err != nil {
+										return []*types.Module{}, fmt.Errorf("%v", err)
+									}
+									// 取得 snbt
+								} else {
+									return []*types.Module{}, fmt.Errorf("ExportBaseOnChunk: Crashed by invalid \"block_entity_data\"")
+								}
+							} else {
+								//return []*types.Module{}, fmt.Errorf("ExportBaseOnChunk: Crashed by could not found \"block_entity_data\"")
+							}
+						} else {
+							return []*types.Module{}, fmt.Errorf("ExportBaseOnChunk: Crashed by invalid \"block_position_data\"")
+						}
+					} else {
+						return []*types.Module{}, fmt.Errorf("ExportBaseOnChunk: Crashed by could not found \"block_position_data\"")
+					}
+				}
+				// 取得方块实体数据
+				if foreground_blockName != "" && (background_blockName == "water" || background_blockName == "flowing_water") {
+					ans = append(ans, &types.Module{
+						Block: &types.Block{
+							Name:        &background_blockName,
+							BlockStates: &background_blockStates,
+						},
+						Point: types.Position{
+							X: i[KEY].BeginX - currentExport.BeginX,
+							Y: i[KEY].BeginY + j - currentExport.BeginY,
+							Z: i[KEY].BeginZ - currentExport.BeginZ,
+						},
+					})
+				}
+				// 含水类方块
+				if foreground_blockName != "" && foreground_blockName != "air" {
+					if hasNBT && commandBlockDataMark {
+						ans = append(ans, &types.Module{
+							Block: &types.Block{
+								Name: &foreground_blockName,
+								Data: uint16(foreground_blockData),
+							},
+							CommandBlockData: &commandBlockData,
+							NBTData:          []byte(string_nbt),
+							Point: types.Position{
+								X: i[KEY].BeginX - currentExport.BeginX,
+								Y: i[KEY].BeginY + j - currentExport.BeginY,
+								Z: i[KEY].BeginZ - currentExport.BeginZ,
+							},
+						})
+					} else if hasNBT && containerDataMark {
+						ans = append(ans, &types.Module{
+							Block: &types.Block{
+								Name: &foreground_blockName,
+								Data: uint16(foreground_blockData),
+							},
+							NBTData:   []byte(string_nbt),
+							ChestData: &containerData,
+							Point: types.Position{
+								X: i[KEY].BeginX - currentExport.BeginX,
+								Y: i[KEY].BeginY + j - currentExport.BeginY,
+								Z: i[KEY].BeginZ - currentExport.BeginZ,
+							},
+						})
+					} else if hasNBT {
+						ans = append(ans, &types.Module{
+							Block: &types.Block{
+								Name:        &foreground_blockName,
+								BlockStates: &foreground_blockStates,
+							},
+							NBTData: []byte(string_nbt),
+							Point: types.Position{
+								X: i[KEY].BeginX - currentExport.BeginX,
+								Y: i[KEY].BeginY + j - currentExport.BeginY,
+								Z: i[KEY].BeginZ - currentExport.BeginZ,
+							},
+						})
+					} else {
+						ans = append(ans, &types.Module{
+							Block: &types.Block{
+								Name:        &foreground_blockName,
+								BlockStates: &foreground_blockStates,
+							},
+							Point: types.Position{
+								X: i[KEY].BeginX - currentExport.BeginX,
+								Y: i[KEY].BeginY + j - currentExport.BeginY,
+								Z: i[KEY].BeginZ - currentExport.BeginZ,
+							},
+						})
+					}
+				}
+				// 放置前景层的方块
+			}
+		}
+	}
+	return ans, nil
+}

--- a/io/special_tasks/lexport_depends/main.go
+++ b/io/special_tasks/lexport_depends/main.go
@@ -148,159 +148,146 @@ func GetMCStructureData(area Area, structure map[string]interface{}) (Mcstructur
 	var background []int16 = []int16{}
 	// 初始化
 	_, ok = structure["structure"]
-	if ok {
-		value_structure, normal = structure["structure"].(map[string]interface{})
-		if normal {
-			_, ok = value_structure["palette"]
-			if ok {
-				value_palette, normal := value_structure["palette"].(map[string]interface{})
-				if normal {
-					_, ok = value_palette["default"]
-					if ok {
-						value_default, normal = value_palette["default"].(map[string]interface{})
-						if normal {
-							_, ok = value_default["block_palette"]
-							if ok {
-								value_block_palette, normal := value_default["block_palette"].([]interface{})
-								if normal {
-									for key, value := range value_block_palette {
-										got, normal := value.(map[string]interface{})
-										if normal {
-											_, ok = got["name"]
-											if ok {
-												value_name, normal := got["name"].(string)
-												if normal {
-													blockPalette = append(blockPalette, value_name)
-												} else {
-													return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"palette\"][\"default\"][\"block_palette\"][%v][\"name\"]", key)
-												}
-											} else {
-												return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"palette\"][\"default\"][\"block_palette\"][%v][\"name\"]", key)
-											}
-											// get block name
-											_, ok = got["states"]
-											if ok {
-												value_states, normal := got["states"].(map[string]interface{})
-												if normal {
-													blockStates, err := TranslateNBTInerface.Compound(value_states, true)
-													if err != nil {
-														return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"palette\"][\"default\"][\"block_palette\"][%v][\"states\"]", key)
-													} else {
-														blockPalette_blockStates = append(blockPalette_blockStates, blockStates)
-													}
-												} else {
-													return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"palette\"][\"default\"][\"block_palette\"][%v][\"states\"]", key)
-												}
-											} else {
-												return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"palette\"][\"default\"][\"block_palette\"][%v]", key)
-											}
-											// get block states
-											_, ok = got["val"]
-											if ok {
-												val, normal := got["val"].(int16)
-												if normal {
-													blockPalette_blockData = append(blockPalette_blockData, val)
-												} else {
-													return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"palette\"][\"default\"][\"block_palette\"][%v][\"val\"]", key)
-												}
-											} else {
-												return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"palette\"][\"default\"][\"block_palette\"][%v][\"val\"]", key)
-											}
-											// get block data
-										} else {
-											return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"palette\"][\"default\"][\"block_palette\"][%v]", key)
-										}
-									}
-								} else {
-									return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"palette\"][\"default\"][\"block_palette\"]")
-								}
-							} else {
-								return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"palette\"][\"default\"][\"block_palette\"]")
-							}
-						} else {
-							return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"palette\"][\"default\"]")
-						}
-					} else {
-						return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"palette\"][\"default\"]")
-					}
-				} else {
-					return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"palette\"]")
-				}
-			}
-		} else {
-			return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"]")
-		}
-	} else {
+	if !ok {
 		return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"]")
 	}
-	// 先把方块状态得到，放于列表 blockPalette 中
-	// 很抱歉，我写出了金字塔屎山（
+	value_structure, normal = structure["structure"].(map[string]interface{})
+	if !normal {
+		return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"]")
+	}
+	// input["structure"]
+	_, ok = value_structure["palette"]
+	if !ok {
+		return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"palette\"]")
+	}
+	value_palette, normal := value_structure["palette"].(map[string]interface{})
+	if !normal {
+		return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"palette\"]")
+	}
+	// input["structure"]["palette"]
+	_, ok = value_palette["default"]
+	if !ok {
+		return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"palette\"][\"default\"]")
+	}
+	value_default, normal = value_palette["default"].(map[string]interface{})
+	if !normal {
+		return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"palette\"][\"default\"]")
+	}
+	// input["structure"]["palette"]["default"]
+	_, ok = value_default["block_palette"]
+	if !ok {
+		return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"palette\"][\"default\"][\"block_palette\"]")
+	}
+	value_block_palette, normal := value_default["block_palette"].([]interface{})
+	if !normal {
+		return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"palette\"][\"default\"][\"block_palette\"]")
+	}
+	// input["structure"]["palette"]["default"]["block_palette"]
+	for key, value := range value_block_palette {
+		got, normal := value.(map[string]interface{})
+		if !normal {
+			return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"palette\"][\"default\"][\"block_palette\"][%v][\"name\"]", key)
+		}
+		// 这里确认下数据类型，就是这个 got 必须得是个复合标签
+		_, ok = got["name"]
+		if !ok {
+			return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"palette\"][\"default\"][\"block_palette\"][%v][\"name\"]", key)
+		}
+		value_name, normal := got["name"].(string)
+		if !normal {
+			return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"palette\"][\"default\"][\"block_palette\"][%v][\"name\"]", key)
+		}
+		blockPalette = append(blockPalette, value_name)
+		// 得到方块的名称
+		// 这里的名称是携带了命名空间 minecraft 的
+		// 命名空间会在后边删掉
+		_, ok = got["states"]
+		if !ok {
+			return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"palette\"][\"default\"][\"block_palette\"][%v][\"states\"]", key)
+		}
+		value_states, normal := got["states"].(map[string]interface{})
+		if !normal {
+			return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"palette\"][\"default\"][\"block_palette\"][%v][\"states\"]", key)
+		}
+		blockStates, err := TranslateNBTInerface.Compound(value_states, true)
+		if err != nil {
+			return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"palette\"][\"default\"][\"block_palette\"][%v][\"states\"]", key)
+		}
+		blockPalette_blockStates = append(blockPalette_blockStates, blockStates)
+		// 得到方块的方块状态
+		_, ok = got["val"]
+		if !ok {
+			return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"palette\"][\"default\"][\"block_palette\"][%v][\"val\"]", key)
+		}
+		val, normal := got["val"].(int16)
+		if !normal {
+			return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"palette\"][\"default\"][\"block_palette\"][%v][\"val\"]", key)
+		}
+		blockPalette_blockData = append(blockPalette_blockData, val)
+		// 得到方块的方块数据值(附加值)
+	}
+	// 这个 for 用于获取调色板的信息的
 	_, ok = value_default["block_position_data"]
 	if ok {
 		value_block_position_data, normal := value_default["block_position_data"].(map[string]interface{})
-		if normal {
-			for key, value := range value_block_position_data {
-				block_position_data, ok := value.(map[string]interface{})
-				if ok {
-					location_of_block_position_data, err := strconv.ParseInt(key, 10, 64)
-					if err != nil {
-						return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"default\"][\"block_position_data\"][%v]", key)
-					}
-					if blockNBT[int(location_of_block_position_data)] == nil {
-						blockNBT[int(location_of_block_position_data)] = make(map[string]interface{})
-					}
-					blockNBT[int(location_of_block_position_data)] = map[string]interface{}{"block_position_data": block_position_data}
-				} else {
-					return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"default\"][\"block_position_data\"][%v]", key)
-				}
-			}
-		} else {
+		if !normal {
 			return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"default\"][\"block_position_data\"]")
+		}
+		for key, value := range value_block_position_data {
+			block_position_data, ok := value.(map[string]interface{})
+			if !ok {
+				return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"default\"][\"block_position_data\"][%v]", key)
+			}
+			location_of_block_position_data, err := strconv.ParseInt(key, 10, 64)
+			if err != nil {
+				return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"default\"][\"block_position_data\"][%v]", key)
+			}
+			if blockNBT[int(location_of_block_position_data)] == nil {
+				blockNBT[int(location_of_block_position_data)] = make(map[string]interface{})
+			}
+			blockNBT[int(location_of_block_position_data)] = map[string]interface{}{"block_position_data": block_position_data}
 		}
 	}
 	// 众所不一定周知，这个方块实体数据可能是不存在的(当然这个我没测试过)
 	// 然后找到所有的方块实体数据，放于 map(blockNBT) 中
 	_, ok = value_structure["block_indices"]
-	if ok {
-		value_block_indices, normal := value_structure["block_indices"].([]interface{})
-		if normal {
-			if len(value_block_indices) == 2 {
-				value_block_indices_0, normal := value_block_indices[0].([]interface{})
-				if normal {
-					for blockLocation_key, blockLocation := range value_block_indices_0 {
-						got, normal := blockLocation.(int32)
-						if normal {
-							foreground = append(foreground, int16(got))
-						} else {
-							return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"block_indices\"][0][%v]", blockLocation_key)
-						}
-					}
-				} else {
-					return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"block_indices\"][0]")
-				}
-				value_block_indices_1, normal := value_block_indices[1].([]interface{})
-				if normal {
-					for blockLocation_key, blockLocation := range value_block_indices_1 {
-						got, normal := blockLocation.(int32)
-						if normal {
-							background = append(background, int16(got))
-						} else {
-							return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"block_indices\"][1][%v]", blockLocation_key)
-						}
-					}
-				} else {
-					return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"block_indices\"][1]")
-				}
-			} else {
-				return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"block_indices\"]")
-			}
-		} else {
-			return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"block_indices\"]")
-		}
-	} else {
+	if !ok {
 		return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"block_indices\"]")
 	}
-	// 然后分别拿到方块池的前景层和背景层
+	value_block_indices, normal := value_structure["block_indices"].([]interface{})
+	if !normal {
+		return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"block_indices\"]")
+	}
+	// input["structure"]["block_indices"]
+	if len(value_block_indices) != 2 {
+		return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"block_indices\"]")
+	}
+	// 这里要求 input["structure"]["block_indices"] 的长度必须为 2
+	// 毕竟是由 前景层 和 背景层 的索引所制成的两张表
+	value_block_indices_0, normal := value_block_indices[0].([]interface{})
+	if !normal {
+		return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"block_indices\"][0]")
+	}
+	for blockLocation_key, blockLocation := range value_block_indices_0 {
+		got, normal := blockLocation.(int32)
+		if !normal {
+			return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"block_indices\"][0][%v]", blockLocation_key)
+		}
+		foreground = append(foreground, int16(got))
+	}
+	// 这里先拿前景层方块的索引表
+	value_block_indices_1, normal := value_block_indices[1].([]interface{})
+	if !normal {
+		return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"block_indices\"][1]")
+	}
+	for blockLocation_key, blockLocation := range value_block_indices_1 {
+		got, normal := blockLocation.(int32)
+		if !normal {
+			return Mcstructure{}, fmt.Errorf("GetMCStructureData: Crashed in input[\"structure\"][\"block_indices\"][1][%v]", blockLocation_key)
+		}
+		background = append(background, int16(got))
+	}
+	// 然后再去拿背景层方块的索引表
 	return Mcstructure{
 		info:                     area,
 		blockPalette:             blockPalette,
@@ -310,6 +297,7 @@ func GetMCStructureData(area Area, structure map[string]interface{}) (Mcstructur
 		background:               background,
 		blockNBT:                 blockNBT,
 	}, nil
+	// 返回扒~
 }
 
 // 根据 mcstructure 的起点和尺寸，以及提供的方块坐标，寻找这个方块在 mcstructure 中的角标
@@ -331,7 +319,16 @@ func SearchForBlock(structureInfo Area, pos BlockPos) (int, error) {
 	return angleMark, nil
 }
 
-func ExportBaseOnChunk(
+/*
+基于区块的大小对整个待导出区域进行重排，并写入对应的方块、NBT数据
+
+allAreas 对整个待导出区域按 64*64 大小拆分，且蛇形拆分(使用SplitArea拆分)，然后再获取拆分得到的各个小区域的 mcstructure 数据，然后处理后制成此 allAreas 表
+
+allAreasFindUse 通过 区域坐标 来查这个区域在 allAreas 表的位置
+
+currentExport 当前 Task 指定的导出区域，也就是根据 set(get) 和 setend(get end) 制成的 Area
+*/
+func ExportBaseOnChunkSize(
 	allAreas []Mcstructure,
 	allAreasFindUse map[AreaLocation]int,
 	currentExport Area,
@@ -407,81 +404,80 @@ func ExportBaseOnChunk(
 				var commandBlockDataMark bool = false
 				var commandBlockData types.CommandBlockData = types.CommandBlockData{}
 				var string_nbt string = ""
-				var err error = fmt.Errorf("")
-
+				var err error = fmt.Errorf("ExportBaseOnChunk: Initialization error")
+				// 变量初始化
+				// 危险！变量初始化这里不要动，不然可能会出现一些意想不到的 Bug
 				got, ok := targetArea.blockNBT[int(VALUE)]
 				if ok {
 					_, ok := got["block_position_data"]
-					if ok {
-						block_position_data, normal := got["block_position_data"].(map[string]interface{})
-						if normal {
-							_, ok := block_position_data["block_entity_data"]
-							if ok {
-								block_entity_data, normal := block_position_data["block_entity_data"].(map[string]interface{})
-								if normal {
-									containerData, err = TranslateNBTInerface.GetContainerDataRun(block_entity_data, foreground_blockName)
-									if fmt.Sprintf("%v", err) != "GetContainerDataRun: Not a container" && err != nil {
-										return []*types.Module{}, fmt.Errorf("%v", err)
-									} else if err == nil {
-										if foreground_blockName == "chest" {
-											useOfChest := "trapped_chest"
-											ans = append(ans, &types.Module{
-												Block: &types.Block{
-													Name: &useOfChest,
-													Data: 0,
-												},
-												Point: types.Position{
-													X: i[KEY].BeginX - currentExport.BeginX,
-													Y: i[KEY].BeginY + j - currentExport.BeginY,
-													Z: i[KEY].BeginZ - currentExport.BeginZ,
-												},
-											})
-										}
-										// 这么处理是为了解决箱子间的连接问题，让所有的箱子都不再连接
-										if foreground_blockName == "trapped_chest" {
-											useOfChest := "chest"
-											ans = append(ans, &types.Module{
-												Block: &types.Block{
-													Name: &useOfChest,
-													Data: 0,
-												},
-												Point: types.Position{
-													X: i[KEY].BeginX - currentExport.BeginX,
-													Y: i[KEY].BeginY + j - currentExport.BeginY,
-													Z: i[KEY].BeginZ - currentExport.BeginZ,
-												},
-											})
-										}
-										// 这么处理是为了解决箱子间的连接问题，让所有的箱子都不再连接
-										containerDataMark = true
-									}
-									// 容器
-									if foreground_blockName == "command_block" || foreground_blockName == "repeating_command_block" || foreground_blockName == "chain_command_block" {
-										commandBlockData, err = TranslateNBTInerface.GetCommandBlockData(block_entity_data, foreground_blockName)
-										if err != nil {
-											return []*types.Module{}, fmt.Errorf("GetCommandBlockData(Started by ExportBaseOnChunk): %v", err)
-										}
-										commandBlockDataMark = true
-									}
-									// 命令方块
-									hasNBT = true
-									string_nbt, err = TranslateNBTInerface.Compound(block_entity_data, false)
-									// string_nbt = fmt.Sprintf("{\"block_entity_data\": %v}", string_nbt)
-									if err != nil {
-										return []*types.Module{}, fmt.Errorf("%v", err)
-									}
-									// 取得 snbt
-								} else {
-									return []*types.Module{}, fmt.Errorf("ExportBaseOnChunk: Crashed by invalid \"block_entity_data\"")
-								}
-							} else {
-								//return []*types.Module{}, fmt.Errorf("ExportBaseOnChunk: Crashed by could not found \"block_entity_data\"")
-							}
-						} else {
-							return []*types.Module{}, fmt.Errorf("ExportBaseOnChunk: Crashed by invalid \"block_position_data\"")
-						}
-					} else {
+					if !ok {
 						return []*types.Module{}, fmt.Errorf("ExportBaseOnChunk: Crashed by could not found \"block_position_data\"")
+					}
+					block_position_data, normal := got["block_position_data"].(map[string]interface{})
+					if !normal {
+						return []*types.Module{}, fmt.Errorf("ExportBaseOnChunk: Crashed by invalid \"block_position_data\"")
+					}
+					// 只要这个方块被记录了 NBT 数据，那么一定会有 block_position_data
+					_, ok = block_position_data["block_entity_data"] // 虽然这个方块被记录了 NBT 数据，但不一定是一个方块实体
+					if ok {
+						block_entity_data, normal := block_position_data["block_entity_data"].(map[string]interface{})
+						if !normal {
+							return []*types.Module{}, fmt.Errorf("ExportBaseOnChunk: Crashed by invalid \"block_entity_data\"")
+						}
+						// 拿一下这个方块的方块实体数据
+						containerData, err = TranslateNBTInerface.GetContainerDataRun(block_entity_data, foreground_blockName)
+						if fmt.Sprintf("%v", err) != "GetContainerDataRun: Not a container" && err != nil {
+							return []*types.Module{}, fmt.Errorf("%v", err)
+						}
+						// 检查一下这个 NBT 方块是不是容器，如果不是会返回一个叫做 "GetContainerDataRun: Not a container" 的错误
+						if err == nil {
+							if foreground_blockName == "chest" {
+								useOfChest := "trapped_chest"
+								ans = append(ans, &types.Module{
+									Block: &types.Block{
+										Name: &useOfChest,
+										Data: 0,
+									},
+									Point: types.Position{
+										X: i[KEY].BeginX - currentExport.BeginX,
+										Y: i[KEY].BeginY + j - currentExport.BeginY,
+										Z: i[KEY].BeginZ - currentExport.BeginZ,
+									},
+								})
+							}
+							// 这么处理是为了解决箱子间的连接问题，让所有的箱子都不再连接；不知道有没有人愿意解决这个问题呢？
+							if foreground_blockName == "trapped_chest" {
+								useOfChest := "chest"
+								ans = append(ans, &types.Module{
+									Block: &types.Block{
+										Name: &useOfChest,
+										Data: 0,
+									},
+									Point: types.Position{
+										X: i[KEY].BeginX - currentExport.BeginX,
+										Y: i[KEY].BeginY + j - currentExport.BeginY,
+										Z: i[KEY].BeginZ - currentExport.BeginZ,
+									},
+								})
+							}
+							// 这么处理是为了解决箱子间的连接问题，让所有的箱子都不再连接；不知道有没有人愿意解决这个问题呢？
+							containerDataMark = true
+						}
+						// 容器
+						if foreground_blockName == "command_block" || foreground_blockName == "repeating_command_block" || foreground_blockName == "chain_command_block" {
+							commandBlockData, err = TranslateNBTInerface.GetCommandBlockData(block_entity_data, foreground_blockName)
+							if err != nil {
+								return []*types.Module{}, fmt.Errorf("GetCommandBlockData(Started by ExportBaseOnChunk): %v", err)
+							}
+							commandBlockDataMark = true
+						}
+						// 命令方块
+						hasNBT = true
+						string_nbt, err = TranslateNBTInerface.Compound(block_entity_data, false)
+						if err != nil {
+							return []*types.Module{}, fmt.Errorf("%v", err)
+						}
+						// 取得 snbt
 					}
 				}
 				// 取得方块实体数据
@@ -500,60 +496,40 @@ func ExportBaseOnChunk(
 				}
 				// 含水类方块
 				if foreground_blockName != "" && foreground_blockName != "air" && foreground_blockName != "undefined" {
-					if hasNBT && commandBlockDataMark {
-						ans = append(ans, &types.Module{
-							Block: &types.Block{
-								Name: &foreground_blockName,
-								Data: uint16(foreground_blockData),
-							},
-							CommandBlockData: &commandBlockData,
-							NBTData:          []byte(string_nbt),
-							Point: types.Position{
-								X: i[KEY].BeginX - currentExport.BeginX,
-								Y: i[KEY].BeginY + j - currentExport.BeginY,
-								Z: i[KEY].BeginZ - currentExport.BeginZ,
-							},
-						})
-					} else if hasNBT && containerDataMark {
-						ans = append(ans, &types.Module{
-							Block: &types.Block{
-								Name: &foreground_blockName,
-								Data: uint16(foreground_blockData),
-							},
-							NBTData:   []byte(string_nbt),
-							ChestData: &containerData,
-							Point: types.Position{
-								X: i[KEY].BeginX - currentExport.BeginX,
-								Y: i[KEY].BeginY + j - currentExport.BeginY,
-								Z: i[KEY].BeginZ - currentExport.BeginZ,
-							},
-						})
-					} else if hasNBT {
-						ans = append(ans, &types.Module{
-							Block: &types.Block{
-								Name:        &foreground_blockName,
-								BlockStates: &foreground_blockStates,
-							},
-							NBTData: []byte(string_nbt),
-							Point: types.Position{
-								X: i[KEY].BeginX - currentExport.BeginX,
-								Y: i[KEY].BeginY + j - currentExport.BeginY,
-								Z: i[KEY].BeginZ - currentExport.BeginZ,
-							},
-						})
-					} else {
-						ans = append(ans, &types.Module{
-							Block: &types.Block{
-								Name:        &foreground_blockName,
-								BlockStates: &foreground_blockStates,
-							},
-							Point: types.Position{
-								X: i[KEY].BeginX - currentExport.BeginX,
-								Y: i[KEY].BeginY + j - currentExport.BeginY,
-								Z: i[KEY].BeginZ - currentExport.BeginZ,
-							},
-						})
+					single := &types.Module{
+						Block: &types.Block{
+							Name: &foreground_blockName,
+						},
+						Point: types.Position{
+							X: i[KEY].BeginX - currentExport.BeginX,
+							Y: i[KEY].BeginY + j - currentExport.BeginY,
+							Z: i[KEY].BeginZ - currentExport.BeginZ,
+						},
 					}
+					// 简单地初始化一下一个单个的元素
+					if commandBlockDataMark {
+						single.Block.Data = uint16(foreground_blockData)
+						single.CommandBlockData = &commandBlockData
+					}
+					// 命令方块
+					if !commandBlockDataMark && containerDataMark {
+						single.Block.Data = uint16(foreground_blockData)
+						single.ChestData = &containerData
+					}
+					// 容器
+					// 优先级比命令方块低一些
+					if hasNBT {
+						single.NBTData = []byte(string_nbt)
+					}
+					// operation 39 - RecordBlockEntityData
+					// 更多信息请见
+					// https://github.com/LNSSPsd/PhoenixBuilder/issues/83
+					if !commandBlockDataMark && !containerDataMark {
+						single.Block.BlockStates = &foreground_blockStates
+					}
+					// 普通方块
+					ans = append(ans, single)
+					// 提交单个元素
 				}
 				// 放置前景层的方块
 			}

--- a/io/special_tasks/lexport_depends/main.go
+++ b/io/special_tasks/lexport_depends/main.go
@@ -485,7 +485,7 @@ func ExportBaseOnChunk(
 					}
 				}
 				// 取得方块实体数据
-				if foreground_blockName != "" && (background_blockName == "water" || background_blockName == "flowing_water") {
+				if foreground_blockName != "" && foreground_blockName != "undefined" && (background_blockName == "water" || background_blockName == "flowing_water") {
 					ans = append(ans, &types.Module{
 						Block: &types.Block{
 							Name:        &background_blockName,
@@ -499,7 +499,7 @@ func ExportBaseOnChunk(
 					})
 				}
 				// 含水类方块
-				if foreground_blockName != "" && foreground_blockName != "air" {
+				if foreground_blockName != "" && foreground_blockName != "air" && foreground_blockName != "undefined" {
 					if hasNBT && commandBlockDataMark {
 						ans = append(ans, &types.Module{
 							Block: &types.Block{

--- a/io/special_tasks/lexport_depends/main.go
+++ b/io/special_tasks/lexport_depends/main.go
@@ -466,7 +466,7 @@ func ExportBaseOnChunk(
 									// 命令方块
 									hasNBT = true
 									string_nbt, err = TranslateNBTInerface.Compound(block_entity_data, false)
-									string_nbt = fmt.Sprintf("{\"block_entity_data\": %v}", string_nbt)
+									// string_nbt = fmt.Sprintf("{\"block_entity_data\": %v}", string_nbt)
 									if err != nil {
 										return []*types.Module{}, fmt.Errorf("%v", err)
 									}


### PR DESCRIPTION
# 更改(对于 `Legacy Export`)
 - 新版本基于 `Block States` 来放置方块
 - 新版本的导出方式发生了改变，通过访问若干个 `64 * 64` 的结构来完成导出，且导出的顺序是蛇形的，可以减小租赁服的负载
 - 修复了一个访问未加载区域时获得的结构内的方块都是空气问题（每导出一个区域前通过 `testforblock` 命令检查目标区域是否加载）
 - 新版本会基于最大 `16 * 16` 的区域（也就是按区块大小）进行重排，现在导入时将是蛇形的
 - 新版本将会写入 `Operation 39 - RecordBlockEntityData` ，且写入的 `方块实体数据` 是一个 `SNBT` 。需要说明的是，无论目标方块是否是 `命令方块` 或可以被 `Replaceitem` 生效的 `容器` ，只要是 `方块实体` ，就会使用 `Operation 39 - RecordBlockEntityData` 。以下是一个 `Operation 39 - RecordBlockEntityData` 记录的 `SNBT`
 ```
{id: Jukebox, isMovable: 1b, x: 229, y: 84, z: 117, RecordItem: {Name: minecraft:music_disc_13, WasPickedUp: 0b, Count: 1b, Damage: 0s}}
```
- 新版本支持了以下容器中的物品（应属 `实验性功能`）
   - 特别地，由于一个容器内的物品可能是一个武器（武器的耐久是记录在 `tag` 的 `Damage` 中），或者一个方块（方块的方块数据值记录在 `Block` 的 `val` 中），因此直接获取 `Damage` 字段的值是不可靠的。本处处理成这样：先获取 `Damage` 字段的值，然后尝试获取物品 `tag` 字段中 `Damage` 的值，然后最后尝试获取方块的 `val` 值。所以，优先级为 `方块数据值 > 物品损坏数据 > 最外层 Damage 数据`
   - 上面的这个获取 `物品数据值` 的步骤并没有确定可以完美覆盖所有情况，因此我在认为此功能应该标为 `实验性功能`
   - 支持的容器如下（特别地，对于 `箱子` 和 `陷阱箱` ，为了规避连接性问题，将全部拆分为单个化的箱子）
     > 高炉/燃烧的高炉
     > 烟熏炉/燃烧的烟熏炉
     > 熔炉/燃烧的熔炉
     > 木桶
     > 箱子
     > 陷阱箱
     > 讲台（需要特别说明的是，讲台由于只能放一个物品，所以储存它的物品数据的不是一个列表，而是一个复合标签）
     > 漏斗
     > 发射器
     > 投掷器
     > 炼药锅/岩浆炼药锅
     > 唱片机（需要特别说明的是，唱片机由于只能放一个物品，所以储存它的物品数据的不是一个列表，而是一个复合标签）
     > 酿造台
   - 为了规避存放物品数据的数据类型不是通常情况下的列表的问题，我作了一些处理，保证所有的 `map[string]interface{}` 都会转变为 `[]interface{}`
- 在导出方块时，若某个方块的前景层不为空，且背景层方块是 `minecraft:water` 或者 `minecraft:flowing_water` ，那么则当作含水类方块处理。如一个含水的 `管珊瑚` 会被处理为 `2` 个方块并按顺序放置，第一个被放置的方块是水方块，第二个被放置的方块才是 `管珊瑚` 方块（请不要认为这种方法是拙劣的，这是目前 **唯一可行** 的办法）
   > 详见 #83 
- 更改了在控制台打印的样式

# 更改(对于 `Legacy Export` 的依赖项)
- 现在在写入 `BDX` 文件时永远会先声明当前文件使用 `117` 号的 `RunTimeId` 调色板表（为了支持 `容器`）
- 现在在写入 `BDX` 文件时可以使用 `Block States` （通过现有 `API` 实现）
- 现在在写入 `BDX` 文件时可以使用 `PlaceRuntimeBlockWithChestDataAndUint32RuntimeID` （通过现有 `API` 实现）
- 写入 `BDX` 文件时若回传的 `mdl.ChestData` 不为空指针，则通过 `containerIndex` 表来查找目标容器在 `117` 号 `RunTimeId` 调色板表下的 `RunTimeId` 。若找不到，也不会返回错误
- 写入 `BDX` 文件时相关的优先级更新为 `命令方块 > 容器 > 普通方块`
- `Block States` 字段现在使用 `*BlockStates` ，即使用一个地址（引用）而非拷贝
- `export.go` 已拆离为多个文件，且新版本的 `lexport` 使用了一个 `lexport_depends` 依赖