### PR TITLE
恢复写入 `NBT` 的相关支持

### DIFF
--- a/fastbuilder/bdump/bdump_legacy.go
+++ b/fastbuilder/bdump/bdump_legacy.go
@@ -292,7 +292,6 @@ func (bdump *BDumpLegacy) writeBlocks(w *bytes.Buffer) error {
 				// ——Happy2018new
 			}
 		}
-		/*
 		if mdl.NBTData != nil {
 			err := writer.WriteCommand(&command.AssignNBTData{
 				Data: mdl.NBTData,
@@ -301,8 +300,6 @@ func (bdump *BDumpLegacy) writeBlocks(w *bytes.Buffer) error {
 				return err
 			}
 		}
-		*/
-		
 	}
 	return nil
 }


### PR DESCRIPTION
它是一个重要的功能，皆在让用户可以以高完整度地在非网易我的世界中国版上的MC版本上还原这些建筑文件。

**我应该强调的是，`PhoenixBuilder` 出色于它的导入和导出功能，而真正意义上的，人们使用 `PhoenixBuilder` 不应该只是为了导入而导入，亦或导出而导出。如果仅仅是这样的话，以导出或者导入为乐趣，这些 `BDX` 文件记录的东西，就都没有意义了。
我应该说，`PhoenixBuilder` 是一个提高 `建筑师` 工作效率的软件，而不是一个让用户以导入导出为乐的软件。这也是我心目中希望的，`PhoenixBuilder` 的社区。
所以， `方块实体` 作为组成建筑物的一个十分重要的部分，不应该就此而忽略。**

理论上，它不会徒增文件大小。现在用户的设备的硬件性能已经足够完备，不需要担心这类问题。
比起担心 `NBT` 十分占用空间，不如看看更占空间的东西——每次 `PlaceBlock` 时都跟个 `方块数据值(附加值)` 或者 `方块状态` （虽然它压缩了，但你总得解压吧）