### PR TITLE
Omega-封禁时间组件升级

### DIFF
--- a/fastbuilder/uqHolder/main.go
+++ b/fastbuilder/uqHolder/main.go
@@ -34,6 +34,7 @@ type Player struct {
 	ActionPermissions       uint32
 	OPPermissionLevel       uint32
 	CustomStoredPermissions uint32
+	DeviceID                string
 	// only when the player can be seen by bot
 	EntityRuntimeID uint64
 	Entity          *Entity
@@ -159,9 +160,7 @@ func (uq *UQHolder) gc(deadline uint64) {
 	for _, p := range uq.playersByUUID {
 		if p.Entity != nil && p.EntityRuntimeID != 0 {
 			if e, hask := uq.EntitiesByRuntimeID[p.EntityRuntimeID]; hask && e.LastUpdateTick < deadline {
-				if _, hasK := uq.entitiesByUniqueID[e.UniqueID]; hasK {
-					delete(uq.entitiesByUniqueID, e.UniqueID)
-				}
+				delete(uq.entitiesByUniqueID, e.UniqueID)
 				delete(uq.EntitiesByRuntimeID, p.EntityRuntimeID)
 			}
 			p.Entity = nil
@@ -177,9 +176,7 @@ func (uq *UQHolder) gc(deadline uint64) {
 	}
 	for _, rtid := range gcEID {
 		if e, hask := uq.EntitiesByRuntimeID[rtid]; hask && e.LastUpdateTick < deadline {
-			if _, hasK := uq.entitiesByUniqueID[e.UniqueID]; hasK {
-				delete(uq.entitiesByUniqueID, e.UniqueID)
-			}
+			delete(uq.entitiesByUniqueID, e.UniqueID)
 			delete(uq.EntitiesByRuntimeID, rtid)
 		}
 	}
@@ -278,8 +275,8 @@ func GetStringContents(s string) []string {
 }
 func ToPlainName(name string) string {
 	if strings.Contains(name, ">") {
-		strings.ReplaceAll(name, ">", " ")
-		strings.ReplaceAll(name, "<", " ")
+		name = strings.ReplaceAll(name, ">", " ")
+		name = strings.ReplaceAll(name, "<", " ")
 	}
 	if name != "" {
 		names := GetStringContents(name)
@@ -297,7 +294,7 @@ func (uq *UQHolder) GetBotName() string {
 	}
 }
 
-var recordNoPlayerEntity = false
+// var recordNoPlayerEntity = false
 
 func (uq *UQHolder) Update(pk packet.Packet) {
 	uq.mu.Lock()
@@ -335,9 +332,7 @@ func (uq *UQHolder) Update(pk packet.Packet) {
 				if p, ok := uq.playersByUUID[e.UUID]; ok {
 					if p.Entity != nil && p.EntityRuntimeID != 0 {
 						if e, hask := uq.EntitiesByRuntimeID[p.EntityRuntimeID]; hask {
-							if _, hasK := uq.entitiesByUniqueID[e.UniqueID]; hasK {
-								delete(uq.entitiesByUniqueID, e.UniqueID)
-							}
+							delete(uq.entitiesByUniqueID, e.UniqueID)
 							delete(uq.EntitiesByRuntimeID, p.EntityRuntimeID)
 						}
 						p.Entity = nil
@@ -434,7 +429,7 @@ func (uq *UQHolder) Update(pk packet.Packet) {
 		player.ActionPermissions = p.ActionPermissions
 		player.OPPermissionLevel = p.PermissionLevel
 		player.CustomStoredPermissions = p.CustomStoredPermissions
-
+		player.DeviceID = p.DeviceID
 	case *packet.MobEquipment:
 		entity := uq.GetEntityByRuntimeID(p.EntityRuntimeID)
 		entity.Slots[p.InventorySlot] = &Equipment{

--- a/omega/components/ban_time.go
+++ b/omega/components/ban_time.go
@@ -15,30 +15,30 @@ import (
 
 type BanTime struct {
 	*defines.BasicComponent
-	Selector             string  `json:"选择器"`
-	Duration             float64 `json:"检查周期"`
-	OnOmegaTakeOver      []defines.Cmd
+	Selector             string      `json:"选择器"`
+	Duration             float64     `json:"检查周期"`
 	OnOmegaTakeOverIn    interface{} `json:"Omega接管时指令"`
-	KickCmd              []defines.Cmd
 	KickCmdIn            interface{} `json:"踢出指令"`
-	AfterOmegaTakeOver   []defines.Cmd
 	AfterOmegaTakeOverIn interface{} `json:"到达封禁时间Omega结束接管时指令"`
 	ScoreboardName       string      `json:"读取封禁时间的计分板名"`
 	FileName             string      `json:"文件名"`
-	mu                   sync.Mutex
-	KickDelay            int `json:"延迟踢出时间"`
-	LoginDelay           int `json:"登录时延迟发送"`
+	KickDelay            int         `json:"延迟踢出时间"`
+	LoginDelay           int         `json:"登录时延迟发送"`
+	OnOmegaTakeOver      []defines.Cmd
+	KickCmd              []defines.Cmd
+	AfterOmegaTakeOver   []defines.Cmd
 	banTime              map[string]time.Time
 	banTimeStr           map[string]string
 	fileChange           bool
+	mu                   sync.Mutex
 }
 
 func (o *BanTime) Init(cfg *defines.ComponentConfig) {
 	m, _ := json.Marshal(cfg.Configs)
-	if err := json.Unmarshal(m, o); err != nil {
+	var err error
+	if err = json.Unmarshal(m, o); err != nil {
 		panic(err)
 	}
-	var err error
 	if o.OnOmegaTakeOver, err = utils.ParseAdaptiveCmd(o.OnOmegaTakeOverIn); err != nil {
 		panic(err)
 	}
@@ -49,12 +49,12 @@ func (o *BanTime) Init(cfg *defines.ComponentConfig) {
 		panic(err)
 	}
 	o.mu = sync.Mutex{}
+	o.banTime = make(map[string]time.Time)
+	o.banTimeStr = make(map[string]string)
 }
 
 func (o *BanTime) Inject(frame defines.MainFrame) {
 	o.Frame = frame
-	o.banTime = make(map[string]time.Time)
-	o.banTimeStr = make(map[string]string)
 	err := frame.GetJsonData(o.FileName, &o.banTimeStr)
 	if err != nil {
 		panic(err)
@@ -67,42 +67,37 @@ func (o *BanTime) Inject(frame defines.MainFrame) {
 	}
 	o.Frame.GetGameListener().AppendLoginInfoCallback(func(entry protocol.PlayerListEntry) {
 		o.mu.Lock()
-		if banTime, hasK := o.banTime[entry.Username]; !hasK {
-			o.mu.Unlock()
-		} else {
+		defer o.mu.Unlock()
+		if banTime, hasK := o.banTime[entry.Username]; hasK {
 			if banTime.After(time.Now()) {
-				o.mu.Unlock()
 				go func() {
 					<-time.NewTimer(time.Duration(o.KickDelay) * time.Second).C
 					o.kick(entry.Username)
 				}()
-
 			} else {
 				delete(o.banTime, entry.Username)
 				delete(o.banTimeStr, entry.Username)
 				o.fileChange = true
-				o.mu.Unlock()
 				go func() {
 					<-time.NewTimer(time.Duration(o.LoginDelay) * time.Second).C
 					utils.LaunchCmdsArray(o.Frame.GetGameControl(), o.AfterOmegaTakeOver, map[string]interface{}{
 						"[player]": entry.Username,
 					}, o.Frame.GetBackendDisplay())
 				}()
-
 			}
 		}
 	})
 }
 
-func (o *BanTime) Signal(signal int) error {
+func (o *BanTime) Signal(signal int) (err error) {
 	switch signal {
 	case defines.SIGNAL_DATA_CHECKPOINT:
 		if o.fileChange {
+			err = o.Frame.WriteJsonDataWithTMP(o.FileName, ".ckpt", o.banTimeStr)
 			o.fileChange = false
-			return o.Frame.WriteJsonDataWithTMP(o.FileName, ".ckpt", o.banTimeStr)
 		}
 	}
-	return nil
+	return err
 }
 
 func (o *BanTime) Stop() error {
@@ -111,27 +106,18 @@ func (o *BanTime) Stop() error {
 }
 
 func (o *BanTime) kick(name string) {
-	s, m, h, d := "?", "?", "?", "?"
 	o.mu.Lock()
-	if banTime, hasK := o.banTime[name]; !hasK {
-		o.mu.Unlock()
-		return
-	} else {
-		o.mu.Unlock()
-		duration := banTime.Sub(time.Now())
-		s = fmt.Sprintf("%v", int(duration.Seconds())%60)
-		m = fmt.Sprintf("%v", int(duration.Minutes())%60)
-		h = fmt.Sprintf("%v", int(duration.Hours())%24)
-		d = fmt.Sprintf("%v", int(duration.Hours())/24)
+	defer o.mu.Unlock()
+	if banTime, hasK := o.banTime[name]; hasK {
+		duration := time.Until(banTime)
+		go utils.LaunchCmdsArray(o.Frame.GetGameControl(), o.KickCmd, map[string]interface{}{
+			"[player]": name,
+			"[day]":    int(duration.Hours()) / 24,
+			"[hour]":   int(duration.Hours()) % 24,
+			"[min]":    int(duration.Minutes()) % 60,
+			"[sec]":    int(duration.Seconds()) % 60,
+		}, o.Frame.GetBackendDisplay())
 	}
-	go utils.LaunchCmdsArray(o.Frame.GetGameControl(), o.KickCmd, map[string]interface{}{
-		"[player]": name,
-		"[day]":    d,
-		"[hour]":   h,
-		"[min]":    m,
-		"[sec]":    s,
-	}, o.Frame.GetBackendDisplay())
-
 }
 
 func (o *BanTime) takeOver(name string) {
@@ -139,7 +125,7 @@ func (o *BanTime) takeOver(name string) {
 		if err != nil {
 			pterm.Error.Printfln("无法获取封禁时间信息 %v %v %v", name, o.ScoreboardName, err)
 		} else if val < 0 {
-			pterm.Error.Printfln("封禁时间指令设计配置有问题，如果封禁时间小于等于 0，则不应该被选择器选中 %v %v %v", name, o.ScoreboardName)
+			pterm.Error.Printfln("封禁时间指令设计配置有问题，如果封禁时间小于等于 0，则不应该被选择器选中 %v %v", name, o.ScoreboardName)
 		} else {
 			duration := time.Second * time.Duration(val)
 			banTime := time.Now().Add(duration)
@@ -149,23 +135,18 @@ func (o *BanTime) takeOver(name string) {
 			o.mu.Unlock()
 			o.fileChange = true
 			go func() {
-				s := fmt.Sprintf("%v", int(duration.Seconds())%60)
-				m := fmt.Sprintf("%v", int(duration.Minutes())%60)
-				h := fmt.Sprintf("%v", int(duration.Hours())%24)
-				d := fmt.Sprintf("%v", int(duration.Hours())/24)
 				utils.LaunchCmdsArray(o.Frame.GetGameControl(), o.OnOmegaTakeOver, map[string]interface{}{
 					"[player]": name,
-					"[day]":    d,
-					"[hour]":   h,
-					"[min]":    m,
-					"[sec]":    s,
+					"[day]":    int(duration.Hours()) / 24,
+					"[hour]":   int(duration.Hours()) % 24,
+					"[min]":    int(duration.Minutes()) % 60,
+					"[sec]":    int(duration.Seconds()) % 60,
 				}, o.Frame.GetBackendDisplay())
 				o.kick(name)
 			}()
 		}
 	})
 }
-
 func (o *BanTime) Activate() {
 	t := time.NewTicker(time.Second * time.Duration(o.Duration))
 	for {

--- a/omega/components/ban_time.go
+++ b/omega/components/ban_time.go
@@ -57,7 +57,7 @@ type bannedDeviceIDDetails struct {
 func (o *BanTime) Init(cfg *defines.ComponentConfig) {
 	if cfg.Version == "0.0.1" {
 		cfg.Version = "0.0.2"
-		cfg.Configs["设备封禁时踢出指令"] = []string{"kick [player] 当前设备已被临时封禁\n剩余时间: [day]天[hour]时[min]分[sec]秒"}
+		cfg.Configs["设备封禁时踢出指令"] = []string{"kick [player] 当前设备已被封禁\n剩余时间: [day]天[hour]时[min]分[sec]秒"}
 		cfg.Configs["是否检查设备ID"] = false
 		cfg.Configs["设备ID相关说明"] = "机器人仅能获取到附近玩家的设备ID, 建议在玩家上线时将机器人传送至其位置"
 		cfg.Upgrade()

--- a/omega/components/ban_time.go
+++ b/omega/components/ban_time.go
@@ -10,30 +10,59 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/pterm/pterm"
 )
 
 type BanTime struct {
 	*defines.BasicComponent
-	Selector             string      `json:"选择器"`
-	Duration             float64     `json:"检查周期"`
 	OnOmegaTakeOverIn    interface{} `json:"Omega接管时指令"`
 	KickCmdIn            interface{} `json:"踢出指令"`
+	KickCmdForDeviceIn   interface{} `json:"设备封禁时踢出指令"`
 	AfterOmegaTakeOverIn interface{} `json:"到达封禁时间Omega结束接管时指令"`
+	Selector             string      `json:"选择器"`
 	ScoreboardName       string      `json:"读取封禁时间的计分板名"`
 	FileName             string      `json:"文件名"`
-	KickDelay            int         `json:"延迟踢出时间"`
 	LoginDelay           int         `json:"登录时延迟发送"`
+	Duration             int         `json:"检查周期"`
+	KickDelay            int         `json:"延迟踢出时间"`
+	EnableDeviceCheck    bool        `json:"是否检查设备ID"`
 	OnOmegaTakeOver      []defines.Cmd
 	KickCmd              []defines.Cmd
+	KickCmdForDevice     []defines.Cmd
 	AfterOmegaTakeOver   []defines.Cmd
-	banTime              map[string]time.Time
-	banTimeStr           map[string]string
 	fileChange           bool
+	needConvertDataFile  bool
+	Data                 *data
 	mu                   sync.Mutex
 }
 
+type data struct {
+	OldData        map[string]string                 `json:"旧版本数据_0.0.1"`
+	BannedUUID     map[uuid.UUID]*bannedUUIDDetails  `json:"玩家封禁数据"`
+	BannedDeviceID map[string]*bannedDeviceIDDetails `json:"设备封禁数据"`
+}
+
+type bannedUUIDDetails struct {
+	BanTime        string `json:"解封时间"`
+	PlayerName     string `json:"封禁时玩家名"`
+	PlayerDeviceID string `json:"封禁时设备ID"`
+}
+
+type bannedDeviceIDDetails struct {
+	BanTime    string `json:"解封时间"`
+	PlayerName string `json:"封禁时玩家名"`
+}
+
 func (o *BanTime) Init(cfg *defines.ComponentConfig) {
+	if cfg.Version == "0.0.1" {
+		cfg.Version = "0.0.2"
+		cfg.Configs["设备封禁时踢出指令"] = []string{"kick [player] 当前设备已被临时封禁\n剩余时间: [day]天[hour]时[min]分[sec]秒"}
+		cfg.Configs["是否检查设备ID"] = false
+		cfg.Configs["设备ID相关说明"] = "机器人仅能获取到附近玩家的设备ID, 建议在玩家上线时将机器人传送至其位置"
+		cfg.Upgrade()
+		o.needConvertDataFile = true
+	}
 	m, _ := json.Marshal(cfg.Configs)
 	var err error
 	if err = json.Unmarshal(m, o); err != nil {
@@ -48,35 +77,57 @@ func (o *BanTime) Init(cfg *defines.ComponentConfig) {
 	if o.AfterOmegaTakeOver, err = utils.ParseAdaptiveCmd(o.AfterOmegaTakeOverIn); err != nil {
 		panic(err)
 	}
+	if o.EnableDeviceCheck {
+		if o.KickCmdForDevice, err = utils.ParseAdaptiveCmd(o.KickCmdForDeviceIn); err != nil {
+			panic(err)
+		}
+	}
+	o.Data = &data{}
+	o.Data.OldData = make(map[string]string)
+	o.Data.BannedUUID = make(map[uuid.UUID]*bannedUUIDDetails)
+	o.Data.BannedDeviceID = make(map[string]*bannedDeviceIDDetails)
 	o.mu = sync.Mutex{}
-	o.banTime = make(map[string]time.Time)
-	o.banTimeStr = make(map[string]string)
 }
 
 func (o *BanTime) Inject(frame defines.MainFrame) {
 	o.Frame = frame
-	err := frame.GetJsonData(o.FileName, &o.banTimeStr)
-	if err != nil {
-		panic(err)
-	}
-	for k, v := range o.banTimeStr {
-		o.banTime[k], err = utils.StringToTimeWithLocal(v + " +0800 CST")
-		if err != nil {
+	var err error
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	// 数据文件转换
+	if o.needConvertDataFile {
+		if err = frame.GetJsonData(o.FileName, &o.Data.OldData); err == nil {
+			o.Frame.WriteJsonDataWithTMP(o.FileName, ".ckpt", o.Data)
+		}
+	} else {
+		if err = frame.GetJsonData(o.FileName, &o.Data); err != nil {
 			panic(err)
 		}
 	}
 	o.Frame.GetGameListener().AppendLoginInfoCallback(func(entry protocol.PlayerListEntry) {
-		o.mu.Lock()
-		defer o.mu.Unlock()
-		if banTime, hasK := o.banTime[entry.Username]; hasK {
+		// 旧数据 + UUID = 新数据
+		if value, ok := o.Data.OldData[entry.Username]; ok {
+			o.Data.BannedUUID[entry.UUID] = &bannedUUIDDetails{
+				PlayerName: entry.Username,
+				BanTime:    value,
+			}
+			delete(o.Data.OldData, entry.Username)
+			o.fileChange = true
+		}
+		// 处理UUID封禁
+		if value, ok := o.Data.BannedUUID[entry.UUID]; ok {
+			banTime, err := utils.StringToTimeWithLocal(value.BanTime + " +0800 CST")
+			if err != nil {
+				panic(err)
+			}
 			if banTime.After(time.Now()) {
 				go func() {
 					<-time.NewTimer(time.Duration(o.KickDelay) * time.Second).C
-					o.kick(entry.Username)
+					o.Frame.GetBackendDisplay().Write(fmt.Sprintf("尝试踢出玩家：%v", entry.Username))
+					o.kick(entry.Username, o.KickCmd, banTime)
 				}()
 			} else {
-				delete(o.banTime, entry.Username)
-				delete(o.banTimeStr, entry.Username)
+				delete(o.Data.BannedUUID, entry.UUID)
 				o.fileChange = true
 				go func() {
 					<-time.NewTimer(time.Duration(o.LoginDelay) * time.Second).C
@@ -87,13 +138,37 @@ func (o *BanTime) Inject(frame defines.MainFrame) {
 			}
 		}
 	})
+	// 处理DeviceID封禁
+	if o.EnableDeviceCheck {
+		o.Frame.GetGameListener().SetOnTypedPacketCallBack(packet.IDAddPlayer, func(p packet.Packet) {
+			pkt := p.(*packet.AddPlayer)
+			if value, ok := o.Data.BannedDeviceID[pkt.DeviceID]; ok {
+				banTime, err := utils.StringToTimeWithLocal(value.BanTime + " +0800 CST")
+				if err != nil {
+					panic(err)
+				}
+				if banTime.After(time.Now()) {
+					go func() {
+						<-time.NewTimer(time.Duration(o.KickDelay) * time.Second).C
+						o.Frame.GetBackendDisplay().Write(fmt.Sprintf("尝试踢出玩家：%v", pkt.Username))
+						o.kick(pkt.Username, o.KickCmdForDevice, banTime)
+					}()
+				} else {
+					o.mu.Lock()
+					delete(o.Data.BannedDeviceID, pkt.DeviceID)
+					o.mu.Unlock()
+					o.fileChange = true
+				}
+			}
+		})
+	}
 }
 
 func (o *BanTime) Signal(signal int) (err error) {
 	switch signal {
 	case defines.SIGNAL_DATA_CHECKPOINT:
 		if o.fileChange {
-			err = o.Frame.WriteJsonDataWithTMP(o.FileName, ".ckpt", o.banTimeStr)
+			err = o.Frame.WriteJsonDataWithTMP(o.FileName, ".ckpt", o.Data)
 			o.fileChange = false
 		}
 	}
@@ -102,22 +177,18 @@ func (o *BanTime) Signal(signal int) (err error) {
 
 func (o *BanTime) Stop() error {
 	fmt.Printf("正在保存 %v\n", o.FileName)
-	return o.Frame.WriteJsonDataWithTMP(o.FileName, ".final", o.banTimeStr)
+	return o.Frame.WriteJsonDataWithTMP(o.FileName, ".final", o.Data)
 }
 
-func (o *BanTime) kick(name string) {
-	o.mu.Lock()
-	defer o.mu.Unlock()
-	if banTime, hasK := o.banTime[name]; hasK {
-		duration := time.Until(banTime)
-		go utils.LaunchCmdsArray(o.Frame.GetGameControl(), o.KickCmd, map[string]interface{}{
-			"[player]": name,
-			"[day]":    int(duration.Hours()) / 24,
-			"[hour]":   int(duration.Hours()) % 24,
-			"[min]":    int(duration.Minutes()) % 60,
-			"[sec]":    int(duration.Seconds()) % 60,
-		}, o.Frame.GetBackendDisplay())
-	}
+func (o *BanTime) kick(name string, cmd []defines.Cmd, banTime time.Time) {
+	duration := time.Until(banTime)
+	go utils.LaunchCmdsArray(o.Frame.GetGameControl(), cmd, map[string]interface{}{
+		"[player]": name,
+		"[day]":    int(duration.Hours()) / 24,
+		"[hour]":   int(duration.Hours()) % 24,
+		"[min]":    int(duration.Minutes()) % 60,
+		"[sec]":    int(duration.Seconds()) % 60,
+	}, o.Frame.GetBackendDisplay())
 }
 
 func (o *BanTime) takeOver(name string) {
@@ -127,12 +198,25 @@ func (o *BanTime) takeOver(name string) {
 		} else if val < 0 {
 			pterm.Error.Printfln("封禁时间指令设计配置有问题，如果封禁时间小于等于 0，则不应该被选择器选中 %v %v", name, o.ScoreboardName)
 		} else {
+			playerUQ := o.Frame.GetGameControl().GetPlayerKit(name).GetRelatedUQ()
 			duration := time.Second * time.Duration(val)
 			banTime := time.Now().Add(duration)
+			banTimeStr := utils.TimeToString(banTime)
 			o.mu.Lock()
-			o.banTime[name] = banTime
-			o.banTimeStr[name] = utils.TimeToString(banTime)
-			o.mu.Unlock()
+			defer o.mu.Unlock()
+			// 写入UUID封禁数据
+			o.Data.BannedUUID[playerUQ.UUID] = &bannedUUIDDetails{
+				BanTime:        banTimeStr,
+				PlayerName:     name,
+				PlayerDeviceID: playerUQ.DeviceID,
+			}
+			// 写入DeviceID封禁数据
+			if o.EnableDeviceCheck && playerUQ.DeviceID != "" {
+				o.Data.BannedDeviceID[playerUQ.DeviceID] = &bannedDeviceIDDetails{
+					BanTime:    banTimeStr,
+					PlayerName: name,
+				}
+			}
 			o.fileChange = true
 			go func() {
 				utils.LaunchCmdsArray(o.Frame.GetGameControl(), o.OnOmegaTakeOver, map[string]interface{}{
@@ -142,7 +226,7 @@ func (o *BanTime) takeOver(name string) {
 					"[min]":    int(duration.Minutes()) % 60,
 					"[sec]":    int(duration.Seconds()) % 60,
 				}, o.Frame.GetBackendDisplay())
-				o.kick(name)
+				o.kick(name, o.KickCmd, banTime)
 			}()
 		}
 	})
@@ -150,20 +234,20 @@ func (o *BanTime) takeOver(name string) {
 func (o *BanTime) Activate() {
 	t := time.NewTicker(time.Second * time.Duration(o.Duration))
 	for {
-		<-t.C
-		o.Frame.GetGameControl().SendCmdAndInvokeOnResponse(fmt.Sprintf("/testfor %v", o.Selector), func(output *packet.CommandOutput) {
+		o.Frame.GetGameControl().SendCmdAndInvokeOnResponse(fmt.Sprintf("testfor %v", o.Selector), func(output *packet.CommandOutput) {
 			if output.SuccessCount > 0 && len(output.OutputMessages) > 0 {
 				ban := &Banned{Victim: []string{}}
 				err := json.Unmarshal([]byte(output.DataSet), &ban)
 				if err != nil {
-					o.Frame.GetBackendDisplay().Write(fmt.Sprintf("fail to get kick info " + err.Error()))
+					o.Frame.GetBackendDisplay().Write(fmt.Sprintf("踢出玩家时遇到问题：%v", err.Error()))
 				} else {
-					o.Frame.GetBackendDisplay().Write(fmt.Sprintf("try to kick %v", ban.Victim))
+					o.Frame.GetBackendDisplay().Write(fmt.Sprintf("尝试踢出玩家：%v", ban.Victim))
 					for _, v := range ban.Victim {
 						o.takeOver(v)
 					}
 				}
 			}
 		})
+		<-t.C
 	}
 }

--- a/omega/mainframe/default_components.json
+++ b/omega/mainframe/default_components.json
@@ -130,7 +130,7 @@
               "价格": 3,
               "商品显示名": "苹果",
               "给予模版": [
-                "give [player] apple [count][currency]",
+                "give [player] apple [count]",
                 "/tellraw [player] {\"rawtext\":[{\"text\":\"2401PT: 苹果是你的了, 共计[totalPrice], 你的钱[moneyHas]->[moneyLeft][currency]([currencyCMD])\"}]}"
               ]
             },
@@ -1631,17 +1631,22 @@
     "来源": "Built-In",
     "配置": {
       "Omega接管时指令": [
-        "tellraw @a  {\"rawtext\":[{\"text\":\"§6[player] 将被封禁 [day]天[hour]时[min]分[sec]秒\"}]}",
+        "tellraw @a {\"rawtext\":[{\"text\":\"§6[player] 将被封禁 [day]天[hour]时[min]分[sec]秒\"}]}",
         "scoreboard players set [player] 封禁时间 0"
       ],
       "踢出指令": [
-        "kick [player] 你已被封禁 [day]天[hour]时[min]分[sec]秒"
+        "kick [player] 你已被封禁\n剩余时间: [day]天[hour]时[min]分[sec]秒"
+      ],
+      "设备封禁时踢出指令": [
+        "kick [player] 当前设备已被封禁\n剩余时间: [day]天[hour]时[min]分[sec]秒"
       ],
       "到达封禁时间Omega结束接管时指令": [
         "tellraw [player] {\"rawtext\":[{\"text\":\"§6你的封禁已经结束，下次请好好做人\"}]}"
       ],
       "延迟踢出时间": 5,
       "登录时延迟发送": 20,
+      "是否检查设备ID": false,
+      "设备ID相关说明": "机器人仅能获取到附近玩家的设备ID, 建议在玩家上线时将机器人传送至其位置",
       "读取封禁时间的计分板名": "封禁时间",
       "检查周期": 3,
       "选择器": "@a[scores={封禁时间=1..}]",


### PR DESCRIPTION
将Omega内置组件 `封禁时间` 升级至 `0.0.2`，为它增加了识别 `DeviceID` 的功能，且将玩家识别信息从昵称更改为UUID

同时，对 `UQHolder` 作出一些更改，使其在接收到 `AddPlayer` 数据包时记录其中的 `DeviceID`

顺便修复了 `商店` 组件默认配置存在错误的问题