### PR TITLE
Update command_block_tweak.go

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -236,7 +236,7 @@ jobs:
     - name: Release
       uses: softprops/action-gh-release@v0.1.14
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.TOKEN }}
       with:
         tag_name: v${{ steps.release_version.outputs.release_version }}
         files: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -236,7 +236,7 @@ jobs:
     - name: Release
       uses: softprops/action-gh-release@v0.1.14
       env:
-        GITHUB_TOKEN: ${{ secrets.TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         tag_name: v${{ steps.release_version.outputs.release_version }}
         files: |

--- a/io/commands/command_block_tweak.go
+++ b/io/commands/command_block_tweak.go
@@ -25,5 +25,5 @@ func (sender *CommandSender) UpdateCommandBlock(x int32,y int32,z int32,d *types
 					C.CString(d.LastOutput), C.int(d.TickDelay),
 					booltochar(d.ExecuteOnFirstTick),
 					booltochar(d.TrackOutput), booltochar(d.Conditional),
-					booltochar(d.NeedRedstone))
+					booltochar(d.NeedsRedstone))
 }


### PR DESCRIPTION
Error: io/commands/command_block_tweak.go:28:19: d.NeedRedstone undefined (type *types.CommandBlockData has no field or method NeedRedstone)
28
make: *** [Makefile:159: build/phoenixbuilder-ios-static.a] Error 2
29
Error: Process completed with exit code 2.

The log means that in line11 io/commands/command_block_tweak.go NeedRedstone IS
n't a correct method.In fact the [latest comment yesterday](https://github.com/LNSSPsd/PhoenixBuilder/commit/32107149f283de6f476e49c0e3cbe65c3c94090d) changed NeedRedstone into NeedsRedstone.Actually,after I add the"s" and started rebuild v4.9.96001 it's worked correctly.