### PR TITLE
修复是否为严格模式的判断

### DIFF
--- a/fastbuilder/builder/bdump.go
+++ b/fastbuilder/builder/bdump.go
@@ -49,7 +49,7 @@ func BDump(config *types.MainConfig, blc chan *types.Module) error {
 	br := brotli.NewReader(file)
 	signed, corrupted, signer_username, err:=bdump.VerifyStreamBDX(br)
 	if !signed {
-		if !config.Strict {
+		if config.Strict {
 			return fmt.Errorf("%s.", I18n.T(I18n.BDump_FileNotSigned))
 		}else{
 			types.ForwardedBrokSender <- fmt.Sprintf("%s!", I18n.T(I18n.BDump_FileNotSigned))


### PR DESCRIPTION
5.0.0版本的是否为严格模式的判断反了，导致必须要加上-S才能导入没有签名的文件