### PR TITLE
New Operation: 41, PlaceBlockWithNBTData

### DIFF
--- a/fastbuilder/bdump/command/place_block_with_nbt_data.go
+++ b/fastbuilder/bdump/command/place_block_with_nbt_data.go
@@ -1,0 +1,61 @@
+package command
+
+import (
+	"encoding/binary"
+	"io"
+)
+
+type PlaceBlockWithNBTData struct {
+	BlockConstantStringID       uint16
+	BlockStatesConstantStringID uint16
+	BlockNBT                    []byte
+}
+
+func (_ *PlaceBlockWithNBTData) ID() uint16 {
+	return 41
+}
+
+func (_ *PlaceBlockWithNBTData) Name() string {
+	return "PlaceBlockWithNBTDataCommand"
+}
+
+func (cmd *PlaceBlockWithNBTData) Marshal(writer io.Writer) error {
+	buf := make([]byte, 2)
+	binary.BigEndian.PutUint16(buf, cmd.BlockConstantStringID)
+	_, err := writer.Write(buf)
+	if err != nil {
+		return err
+	}
+	binary.BigEndian.PutUint16(buf, cmd.BlockStatesConstantStringID)
+	_, err = writer.Write(buf)
+	if err != nil {
+		return err
+	}
+	lenBuf := make([]byte, 4)
+	binary.BigEndian.PutUint32(lenBuf, uint32(len(cmd.BlockNBT)))
+	_, err = writer.Write(append(lenBuf, cmd.BlockNBT...))
+	return err
+}
+
+func (cmd *PlaceBlockWithNBTData) Unmarshal(reader io.Reader) error {
+	buf := make([]byte, 2)
+	_, err := io.ReadAtLeast(reader, buf, 2)
+	if err != nil {
+		return err
+	}
+	cmd.BlockConstantStringID = binary.BigEndian.Uint16(buf)
+	buf = make([]byte, 2)
+	_, err = io.ReadAtLeast(reader, buf, 2)
+	if err != nil {
+		return err
+	}
+	cmd.BlockStatesConstantStringID = binary.BigEndian.Uint16(buf)
+	lenBuf := make([]byte, 4)
+	_, err = io.ReadAtLeast(reader, lenBuf, 4)
+	if err != nil {
+		return err
+	}
+	cmd.BlockNBT = make([]byte, int(binary.BigEndian.Uint32(lenBuf)))
+	_, err = io.ReadAtLeast(reader, cmd.BlockNBT, len(cmd.BlockNBT))
+	return err
+}

--- a/fastbuilder/bdump/command/pool.go
+++ b/fastbuilder/bdump/command/pool.go
@@ -36,5 +36,6 @@ var BDumpCommandPool map[uint16]func()Command = map[uint16]func()Command {
 	38: func()Command { return &PlaceRuntimeBlockWithChestDataAndUint32RuntimeID{} },
 	39: func()Command { return &AssignDebugData{} },
 	40: func()Command { return &PlaceBlockWithChestData{} },
+	41: func()Command { return &PlaceBlockWithNBTData{} },
 	88: func()Command { return &Terminate{} },
 }

--- a/fastbuilder/builder/bdump.go
+++ b/fastbuilder/builder/bdump.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"phoenixbuilder/fastbuilder/bdump"
 	"phoenixbuilder/fastbuilder/bdump/command"
+
 	//bridge_path "phoenixbuilder/fastbuilder/builder/path"
 	I18n "phoenixbuilder/fastbuilder/i18n"
 	"phoenixbuilder/fastbuilder/types"
@@ -350,6 +351,27 @@ func BDump(config *types.MainConfig, blc chan *types.Module) error {
 					Name:        blockName,
 					BlockStates: blockStates,
 				},
+				Point: types.Position{
+					X: brushPosition[0] + config.Position.X,
+					Y: brushPosition[1] + config.Position.Y,
+					Z: brushPosition[2] + config.Position.Z,
+				},
+			}
+		case *command.PlaceBlockWithNBTData:
+			if int(cmd.BlockConstantStringID) >= len(blocksStrPool) {
+				return fmt.Errorf("Error: BlockID exceeded StringPool")
+			}
+			if int(cmd.BlockStatesConstantStringID) >= len(blocksStrPool) {
+				return fmt.Errorf("Error: BlockStatesID exceeded StringPool")
+			}
+			blockName := &blocksStrPool[int(cmd.BlockConstantStringID)]
+			blockStates := blocksStrPool[int(cmd.BlockStatesConstantStringID)]
+			blc <- &types.Module{
+				Block: &types.Block{
+					Name:        blockName,
+					BlockStates: blockStates,
+				},
+				NBTData: cmd.BlockNBT,
 				Point: types.Position{
 					X: brushPosition[0] + config.Position.X,
 					Y: brushPosition[1] + config.Position.Y,


### PR DESCRIPTION
## 更改
为 `BDX` 文件格式添加了一个新的操作符，用于放置 `NBT` 方块，但目前还未提供任何实际支持，导出时也不会写入相关数据。

相应的语法如下。

```
operationNumber 41; BlockConstantStringID uint16; BlockStatesConstantStringID uint16; uint32 length; blockNBT buffer[length]
```