### PR TITLE
 Hot fix for `export` function

### DIFF
--- a/fastbuilder/bdump/bdump.go
+++ b/fastbuilder/bdump/bdump.go
@@ -307,9 +307,9 @@ func (bdump *BDump) writeBlocks(w io.Writer) error {
 			}
 		}
 		/*
-			if mdl.NBTData != nil {
-				err := writer.WriteCommand(&command.AssignNBTData{
-					Data: mdl.NBTData,
+			if mdl.DebugNBTData != nil {
+				err := writer.WriteCommand(&command.AssignDebugData{
+					Data: mdl.DebugNBTData,
 				})
 				if err != nil {
 					return err

--- a/fastbuilder/types/block.go
+++ b/fastbuilder/types/block.go
@@ -3,6 +3,7 @@ package types
 type Module struct {
 	Block            *Block
 	CommandBlockData *CommandBlockData
+	DebugNBTData     []byte
 	NBTData          []byte
 	NBTMap           map[string]interface{}
 	//Entity *Entity

--- a/io/special_tasks/export.go
+++ b/io/special_tasks/export.go
@@ -350,7 +350,7 @@ func CreateExportTask(commandLine string, env *environment.PBEnvironment) *task.
 						},
 						CommandBlockData: cbdata,
 						ChestData:        chestData,
-						NBTData:          nbtData,
+						DebugNBTData:     nbtData,
 						Point: types.Position{
 							X: x,
 							Y: y,


### PR DESCRIPTION
修复了 `Export` 在导出 `方块实体` 型的方块时会把 `_tag` 型的 `NBT` 当作正常 `NBT` 来处理（指使用 `Operation 41 - PlaceBlockWithNBTData` 来 `Assign` 这类数据）的问题。