### PR TITLE
修复导入和导出相关的问题

### DIFF
--- a/fastbuilder/bdump/blockNBT/CommandBlock/legacyMethod.go
+++ b/fastbuilder/bdump/blockNBT/CommandBlock/legacyMethod.go
@@ -26,17 +26,18 @@ func (c *CommandBlock) PlaceCommandBlockWithLegacyMethod(block *types.Module, cf
 	} else if block.CommandBlockData.Mode == packet.CommandBlockRepeating {
 		blockName = "repeating_command_block"
 	}
-	block.Block.Name = &blockName
-	c.BlockEntityDatas.Block.Name = blockName
-	// 确定命令方块的类型
 	if block.Block == nil {
+		block.Block = &types.Block{}
+		block.Block.Name = &blockName
 		err := c.WriteDatas(false)
 		if err != nil {
 			return fmt.Errorf("PlaceCommandBlockWithLegacyMethod: %v", err)
 		}
 		return nil
 	}
-	// 如果是 operation 26 - SetCommandBlockData
+	block.Block.Name = &blockName
+	c.BlockEntityDatas.Block.Name = blockName
+	// 确定命令方块的类型 & 如果是 operation 26 - SetCommandBlockData
 	request := commands_generator.SetBlockRequest(block, cfg)
 	if c.BlockEntityDatas.Datas.FastMode {
 		err := c.BlockEntityDatas.API.SendSettingsCommand(request, true)

--- a/fastbuilder/bdump/command/set_command_block_data.go
+++ b/fastbuilder/bdump/command/set_command_block_data.go
@@ -61,6 +61,7 @@ func (cmd *SetCommandBlockData) Marshal(writer io.Writer) error {
 }
 
 func (cmd *SetCommandBlockData) Unmarshal(reader io.Reader) error {
+	cmd.CommandBlockData = &types.CommandBlockData{}
 	buf:=make([]byte, 4)
 	_, err:=io.ReadAtLeast(reader, buf, 4)
 	if err!=nil {

--- a/minecraft/nbt/decode.go
+++ b/minecraft/nbt/decode.go
@@ -441,9 +441,11 @@ func (d *Decoder) tag() (tagType byte, tagName string, err error) {
 	if d.depth >= maximumNestingDepth {
 		return 0, "", MaximumDepthReachedError{}
 	}
+	/*
 	if d.r.off >= maximumNetworkOffset && d.Encoding == NetworkLittleEndian {
 		return 0, "", MaximumBytesReadError{}
 	}
+	*/
 	tagType, err = d.r.ReadByte()
 	if err != nil {
 		return 0, "", BufferOverrunError{Op: "ReadTag"}


### PR DESCRIPTION
修复了下列问题
- 在解码 `Operation 26(SetCommandBlockData)` 时因未初始化结构体导致的空指针行为
- 在实际放置命令方块时在初始化结构体前提前赋值导致的空指针行为
- 修复了 `lexport` 导出时如果遭遇了字节数超过 `4 * 1024 * 1024` 的 `packet.StructureTemplateDataResponse` 时会导致 `nbt: limit of bytes read 4194304 with NetworkLittleEndian format exhausted` 的问题，现在已经去除了该限制