### PR TITLE
fix ConnectionEstablished msg missing

### DIFF
--- a/fastbuilder/core/core.go
+++ b/fastbuilder/core/core.go
@@ -176,6 +176,8 @@ func InitClient(env *environment.PBEnvironment) {
 				_, _ = bufio.NewReader(os.Stdin).ReadString('\n')
 			}
 			panic(err)
+		} else {
+		pterm.Println(I18n.T(I18n.ConnectionEstablished))
 		}
 		conn = cconn
 		if len(env.RespondUser) == 0 {


### PR DESCRIPTION
修复 #278 关于`“成功连接到服务器”的提示消失`的问题