### PR TITLE
修复间歇性崩溃问题

### DIFF
--- a/fastbuilder/core/core.go
+++ b/fastbuilder/core/core.go
@@ -410,7 +410,7 @@ func EnterWorkerThread(env *environment.PBEnvironment, breaker chan struct{}) {
 				} else if strings.Contains(string(p.Content), "GetMCPCheckNum") {
 					// This shit sucks, so as netease.
 					if getchecknum_everPassed {
-						break
+						continue
 					}
 					//fmt.Printf("%X", p.Content)
 					//fmt.Printf("%s\n", p.Content)


### PR DESCRIPTION
修复了 `PhoenixBuilder` 会间歇性退出的问题。

其等级应该被评估 _严重_ ，因为这会导致大概每 `4` 分钟发生一次退出。

这是针对 #286 的子修复，因为我在提前有关代码块的时移除了 `switch case` ，但我忘记了原代码内的 `break` 应该改为 `continue` 。

That's my mistake, sorry.