### PR TITLE
New flag named `AssignNBTData` for `bdump` and fix some bugs

### DIFF
--- a/fastbuilder/bdump/blockNBT/Container.go
+++ b/fastbuilder/bdump/blockNBT/Container.go
@@ -217,7 +217,7 @@ func (c *Container) WriteDatas() error {
 				Name:   value.Name,
 				Count:  value.Count,
 				Damage: value.Damage,
-				Slot:   value.Count,
+				Slot:   value.Slot,
 			},
 			"",
 		)

--- a/fastbuilder/bdump/blockNBT/interface.go
+++ b/fastbuilder/bdump/blockNBT/interface.go
@@ -1,0 +1,9 @@
+package blockNBT
+
+// 用于放置方块实体的通用接口
+type GeneralBlockNBT interface {
+	// 解析 NBT(map[string]interface{}) 为 golang struct
+	Decode() error
+	// 放置方块并以合法手段写入方块实体数据
+	WriteDatas() error
+}

--- a/fastbuilder/bdump/blockNBT/pool.go
+++ b/fastbuilder/bdump/blockNBT/pool.go
@@ -69,39 +69,3 @@ var SupportBlocksPool map[string]string = map[string]string{
 	"warped_hanging_sign":    "Sign",
 	// 告示牌
 }
-
-// 用于放置方块实体的通用接口
-type GeneralBlockNBT interface {
-	Decode() error     // 解析 NBT(map[string]interface{}) 数据为 GoLang Struct
-	WriteDatas() error // 放置方块并以正常玩家的行为写入方块实体数据
-}
-
-// 检查这个方块实体是否已被支持。
-// 如果尚未被支持，则返回空字符串，否则返回这种方块的类型。
-// 以告示牌为例，所有的告示牌都可以写作为 Sign
-func CheckIfIsEffectiveNBTBlock(blockName string) string {
-	value, ok := SupportBlocksPool[blockName]
-	if ok {
-		return value
-	}
-	return ""
-}
-
-// 取得用于放置目标方块实体的 接口/方法
-func GetMethod(pack Package) GeneralBlockNBT {
-	switch pack.Datas.Type {
-	case "CommandBlock":
-		return &CommandBlock{Package: &pack, NeedToPlaceBlock: true}
-		// 命令方块
-	case "Container":
-		return &Container{Package: &pack}
-		// 容器
-	case "Sign":
-		return &Sign{Package: &pack}
-		// 告示牌
-	default:
-		return &Default{Package: &pack}
-		// 其他尚且未被支持的方块实体
-	}
-	// 返回值
-}

--- a/fastbuilder/bdump/blockNBT/utils.go
+++ b/fastbuilder/bdump/blockNBT/utils.go
@@ -1,0 +1,58 @@
+package blockNBT
+
+import (
+	"fmt"
+	"phoenixbuilder/fastbuilder/mcstructure"
+	"phoenixbuilder/fastbuilder/types"
+	"strings"
+)
+
+// 从 SupportBlocksPool 检查这个方块实体是否已被支持。
+// 如果尚未被支持，则返回空字符串，否则返回这种方块的类型。
+// 以告示牌为例，所有的告示牌都可以写作为 Sign
+func checkIfIsEffectiveNBTBlock(blockName string) string {
+	value, ok := SupportBlocksPool[blockName]
+	if ok {
+		return value
+	}
+	return ""
+}
+
+// 将 types.Module 转换为 blockNBT_depends.GeneralBlock
+func parseBlockModule(singleBlock *types.Module) (GeneralBlock, error) {
+	// init var
+	got, err := mcstructure.ParseStringNBT(singleBlock.Block.BlockStates, true)
+	if err != nil {
+		return GeneralBlock{}, fmt.Errorf("parseBlockModule: Could not parse block states; singleBlock.Block.BlockStates = %#v", singleBlock.Block.BlockStates)
+	}
+	blockStates, normal := got.(map[string]interface{})
+	if !normal {
+		return GeneralBlock{}, fmt.Errorf("parseBlockModule: The target block states is not map[string]interface{}; got = %#v", got)
+	}
+	// get block states
+	return GeneralBlock{
+		Name:   strings.Replace(strings.ToLower(strings.ReplaceAll(*singleBlock.Block.Name, " ", "")), "minecraft:", "", 1),
+		States: blockStates,
+		NBT:    singleBlock.NBTMap,
+	}, nil
+	// return
+}
+
+// 取得用于放置目标方块实体的 接口/方法
+func getMethod(pack Package) GeneralBlockNBT {
+	switch pack.Datas.Type {
+	case "CommandBlock":
+		return &CommandBlock{Package: &pack, NeedToPlaceBlock: true}
+		// 命令方块
+	case "Container":
+		return &Container{Package: &pack}
+		// 容器
+	case "Sign":
+		return &Sign{Package: &pack}
+		// 告示牌
+	default:
+		return &Default{Package: &pack}
+		// 其他尚且未被支持的方块实体
+	}
+	// 返回值
+}

--- a/fastbuilder/function/internal.go
+++ b/fastbuilder/function/internal.go
@@ -193,7 +193,7 @@ func InitInternalFunctions(fh *FunctionHolder) {
 				FunctionType: FunctionTypeSimple,
 				Content: func(env *environment.PBEnvironment, _ []interface{}) {
 					env.GlobalAPI.(*GlobalAPI.GlobalAPI).SendSettingsCommand("gamerule sendcommandfeedback true", false)
-					env.GlobalAPI.(*GlobalAPI.GlobalAPI).SendCommand(fmt.Sprintf("execute @a[name=\"%s\"] ~ ~ ~ testforblock ~ ~ ~ air", env.RespondUser), configuration.ZeroId)
+					env.GlobalAPI.(*GlobalAPI.GlobalAPI).SendCommand(fmt.Sprintf("execute @a[name=\"%s\"] ~ ~ ~ testforblock ~ ~ ~ air", env.RespondUser), configuration.OneId)
 				},
 			},
 		},

--- a/fastbuilder/parsing/parsing.go
+++ b/fastbuilder/parsing/parsing.go
@@ -61,6 +61,7 @@ func Parse(Message string, defaultConfig *types.MainConfig) (*types.MainConfig, 
 		Height:             0,
 		Method:             "replace",
 		OldMethod:          "keep",
+		AssignNBTData:      false,
 		ExcludeCommands:    false,
 		InvalidateCommands: false,
 	}
@@ -69,6 +70,8 @@ func Parse(Message string, defaultConfig *types.MainConfig) (*types.MainConfig, 
 	var tempBlockData int
 	var tempOldBlockData int
 	//Length,  Width and Height
+	FlagSet.BoolVar(&Config.AssignNBTData, "assignnbtdata", defaultConfig.AssignNBTData, "Assign NBT data to blocks by lawful means while importing")
+	FlagSet.BoolVar(&Config.AssignNBTData, "nbt", defaultConfig.AssignNBTData, "Assign NBT data to blocks by lawful means while importing")
 	FlagSet.BoolVar(&Config.ExcludeCommands, "excludecommands", defaultConfig.ExcludeCommands, "Exclude commands in command blocks")
 	FlagSet.BoolVar(&Config.InvalidateCommands, "invalidatecommands", defaultConfig.InvalidateCommands, "Invalidate commands in command blocks")
 	FlagSet.BoolVar(&Config.Strict, "strict", defaultConfig.Strict, "Break if the file isn't signed")

--- a/fastbuilder/parsing/parsing.go
+++ b/fastbuilder/parsing/parsing.go
@@ -3,65 +3,65 @@ package parsing
 import (
 	"flag"
 	"fmt"
-	"phoenixbuilder/fastbuilder/i18n"
+	I18n "phoenixbuilder/fastbuilder/i18n"
 	"phoenixbuilder/fastbuilder/types"
 	"strings"
 )
 
 func Parse(Message string, defaultConfig *types.MainConfig) (*types.MainConfig, error) {
 	//SLC := strings.Split(Message," ")
-	isTransIMI:=false
-	isInQuote:=false
+	isTransIMI := false
+	isInQuote := false
 	var SLC []string
-	curmsg:=""
-	for _,c:=range Message {
+	curmsg := ""
+	for _, c := range Message {
 		if isTransIMI {
-			isTransIMI=false
-			curmsg+=string(c)
+			isTransIMI = false
+			curmsg += string(c)
 			continue
 		}
-		if(c=='\\') {
-			isTransIMI=true
+		if c == '\\' {
+			isTransIMI = true
 			continue
 		}
-		if(c=='"'){
-			isInQuote=(!isInQuote)
+		if c == '"' {
+			isInQuote = (!isInQuote)
 			continue
 		}
-		if(c==' '&&!isInQuote){
-			SLC=append(SLC,curmsg)
-			curmsg=""
+		if c == ' ' && !isInQuote {
+			SLC = append(SLC, curmsg)
+			curmsg = ""
 			continue
 		}
-		if(c=='#'){
+		if c == '#' {
 			break
 		}
-		curmsg+=string(c)
+		curmsg += string(c)
 	}
-	if(len(curmsg)>0){
-		SLC=append(SLC,curmsg)
-		curmsg=""
+	if len(curmsg) > 0 {
+		SLC = append(SLC, curmsg)
+		curmsg = ""
 	}
 	//fmt.Printf("%v\n",SLC)
-	if(isInQuote) {
+	if isInQuote {
 		return nil, fmt.Errorf(I18n.T(I18n.Parsing_UnterminatedQuotedString))
-	}else if(isTransIMI) {
+	} else if isTransIMI {
 		return nil, fmt.Errorf(I18n.T(I18n.Parsing_UnterminatedEscape))
 	}
 	Config := &types.MainConfig{
-		Execute:   "",
-		Block:     &types.ConstBlock{},
-		OldBlock:  &types.ConstBlock{},
+		Execute:  "",
+		Block:    &types.ConstBlock{},
+		OldBlock: &types.ConstBlock{},
 		//Begin:     types.Position{},
-		End:       defaultConfig.End,
-		Position:  defaultConfig.Position,
-		Radius:    0,
-		Length:    0,
-		Width:     0,
-		Height:    0,
-		Method:    "replace",
-		OldMethod: "keep",
-		ExcludeCommands: false,
+		End:                defaultConfig.End,
+		Position:           defaultConfig.Position,
+		Radius:             0,
+		Length:             0,
+		Width:              0,
+		Height:             0,
+		Method:             "replace",
+		OldMethod:          "keep",
+		ExcludeCommands:    false,
 		InvalidateCommands: false,
 	}
 
@@ -69,44 +69,43 @@ func Parse(Message string, defaultConfig *types.MainConfig) (*types.MainConfig, 
 	var tempBlockData int
 	var tempOldBlockData int
 	//Length,  Width and Height
-	FlagSet.BoolVar(&Config.ExcludeCommands,"excludecommands",defaultConfig.ExcludeCommands,"Exclude commands in command blocks")
-	FlagSet.BoolVar(&Config.InvalidateCommands,"invalidatecommands",defaultConfig.InvalidateCommands,"Invalidate commands in command blocks")
-	FlagSet.BoolVar(&Config.Strict,"strict",defaultConfig.Strict,"Break if the file isn't signed")
-	FlagSet.BoolVar(&Config.Strict,"S",defaultConfig.Strict,"Break if the file isn't signed")
-	
-	FlagSet.IntVar(&Config.Length,"length",defaultConfig.Length,"The length")
-	FlagSet.IntVar(&Config.Length,"l",defaultConfig.Length,"The length")
-	FlagSet.IntVar(&Config.Width,"width",defaultConfig.Width,"The width")
-	FlagSet.IntVar(&Config.Width,"w",defaultConfig.Width,"The width")
-	FlagSet.IntVar(&Config.Height,"height",defaultConfig.Height,"The height")
-	FlagSet.IntVar(&Config.Height,"h",defaultConfig.Height,"The height")
+	FlagSet.BoolVar(&Config.ExcludeCommands, "excludecommands", defaultConfig.ExcludeCommands, "Exclude commands in command blocks")
+	FlagSet.BoolVar(&Config.InvalidateCommands, "invalidatecommands", defaultConfig.InvalidateCommands, "Invalidate commands in command blocks")
+	FlagSet.BoolVar(&Config.Strict, "strict", defaultConfig.Strict, "Break if the file isn't signed")
+	FlagSet.BoolVar(&Config.Strict, "S", defaultConfig.Strict, "Break if the file isn't signed")
+
+	FlagSet.IntVar(&Config.Length, "length", defaultConfig.Length, "The length")
+	FlagSet.IntVar(&Config.Length, "l", defaultConfig.Length, "The length")
+	FlagSet.IntVar(&Config.Width, "width", defaultConfig.Width, "The width")
+	FlagSet.IntVar(&Config.Width, "w", defaultConfig.Width, "The width")
+	FlagSet.IntVar(&Config.Height, "height", defaultConfig.Height, "The height")
+	FlagSet.IntVar(&Config.Height, "h", defaultConfig.Height, "The height")
 	//Radius
-	FlagSet.IntVar(&Config.Radius,"radius",defaultConfig.Radius,"The radius")
-	FlagSet.IntVar(&Config.Radius,"r",defaultConfig.Radius,"The radius")
+	FlagSet.IntVar(&Config.Radius, "radius", defaultConfig.Radius, "The radius")
+	FlagSet.IntVar(&Config.Radius, "r", defaultConfig.Radius, "The radius")
 	// Map Art Configuration
 	FlagSet.IntVar(&Config.MapX, "mapX", defaultConfig.MapX, "Take X maps in map art")
 	FlagSet.IntVar(&Config.MapZ, "mapZ", defaultConfig.MapZ, "Take Z maps in map art")
 	FlagSet.IntVar(&Config.MapY, "mapY", defaultConfig.MapY, "Available Height (blocks) for 3D map art")
 	//Facing, Path, Shape
-	FlagSet.StringVar(&Config.Facing,"facing",defaultConfig.Facing,"Building's facing")
-	FlagSet.StringVar(&Config.Facing,"f",defaultConfig.Facing,"Building's facing")
-	FlagSet.StringVar(&Config.Path,"path",defaultConfig.Path,"The path of file")
-	FlagSet.StringVar(&Config.Path,"p",defaultConfig.Path,"The path of file")
-	FlagSet.StringVar(&Config.Shape,"shape",defaultConfig.Shape,"The path of file")
-	FlagSet.StringVar(&Config.Shape,"s",defaultConfig.Shape,"The path of file")
+	FlagSet.StringVar(&Config.Facing, "facing", defaultConfig.Facing, "Building's facing")
+	FlagSet.StringVar(&Config.Facing, "f", defaultConfig.Facing, "Building's facing")
+	FlagSet.StringVar(&Config.Path, "path", defaultConfig.Path, "The path of file")
+	FlagSet.StringVar(&Config.Path, "p", defaultConfig.Path, "The path of file")
+	FlagSet.StringVar(&Config.Shape, "shape", defaultConfig.Shape, "The path of file")
+	FlagSet.StringVar(&Config.Shape, "s", defaultConfig.Shape, "The path of file")
 	//Block
-	FlagSet.StringVar(&Config.Block.Name,"block",defaultConfig.Block.Name,"Blocks that make up the building")
-	FlagSet.StringVar(&Config.Block.Name,"b",defaultConfig.Block.Name,"Blocks that make up the building")
-	FlagSet.IntVar(&tempBlockData,"data",int(defaultConfig.Block.Data),"The data of Block")
-	FlagSet.IntVar(&tempBlockData,"d",int(defaultConfig.Block.Data),"The data of Block")
+	FlagSet.StringVar(&Config.Block.Name, "block", defaultConfig.Block.Name, "Blocks that make up the building")
+	FlagSet.StringVar(&Config.Block.Name, "b", defaultConfig.Block.Name, "Blocks that make up the building")
+	FlagSet.IntVar(&tempBlockData, "data", int(defaultConfig.Block.Data), "The data of Block")
+	FlagSet.IntVar(&tempBlockData, "d", int(defaultConfig.Block.Data), "The data of Block")
 	//OldBlock
-	FlagSet.StringVar(&Config.OldBlock.Name,"old_block",defaultConfig.OldBlock.Name,"Blocks that make up the building")
-	FlagSet.StringVar(&Config.OldBlock.Name,"ob",defaultConfig.OldBlock.Name,"Blocks that make up the building")
-	FlagSet.IntVar(&tempOldBlockData,"old_data",int(defaultConfig.OldBlock.Data),"The data of Block")
-	FlagSet.IntVar(&tempOldBlockData,"od",int(defaultConfig.OldBlock.Data),"The data of Block")
+	FlagSet.StringVar(&Config.OldBlock.Name, "old_block", defaultConfig.OldBlock.Name, "Blocks that make up the building")
+	FlagSet.StringVar(&Config.OldBlock.Name, "ob", defaultConfig.OldBlock.Name, "Blocks that make up the building")
+	FlagSet.IntVar(&tempOldBlockData, "old_data", int(defaultConfig.OldBlock.Data), "The data of Block")
+	FlagSet.IntVar(&tempOldBlockData, "od", int(defaultConfig.OldBlock.Data), "The data of Block")
 	// Resume
-	FlagSet.Float64Var(&Config.ResumeFrom,"resume",float64(defaultConfig.ResumeFrom),"Resume Construction from percentage, async only")
-
+	FlagSet.Float64Var(&Config.ResumeFrom, "resume", float64(defaultConfig.ResumeFrom), "Resume Construction from percentage, async only")
 
 	FlagSet.Parse(SLC[1:])
 	/*for k, _ := range builder.Builder {
@@ -116,7 +115,7 @@ func Parse(Message string, defaultConfig *types.MainConfig) (*types.MainConfig, 
 	}*/
 	Config.Execute = SLC[0]
 	// Since the function system exists ^^
-	
+
 	//for index, v := range SLC {
 	//	if v == "-p" || v == "--position" {
 	//		x, xe := strconv.Atoi(SLC[index + 1])
@@ -127,20 +126,20 @@ func Parse(Message string, defaultConfig *types.MainConfig) (*types.MainConfig, 
 	//		}
 	//	}
 	//}
-	Config.Block.Data=uint16(tempBlockData)
-	Config.OldBlock.Data=uint16(tempOldBlockData)
+	Config.Block.Data = uint16(tempBlockData)
+	Config.OldBlock.Data = uint16(tempOldBlockData)
 	return Config, nil
 }
 
 func PipeParse(Message string, config *types.MainConfig) ([]*types.MainConfig, error) {
-	ChatSlice := strings.Split(Message,"|")
+	ChatSlice := strings.Split(Message, "|")
 	var Configs []*types.MainConfig
 	for _, v := range ChatSlice {
-		pv, err:=Parse(v,config)
-		if err!=nil {
+		pv, err := Parse(v, config)
+		if err != nil {
 			return nil, err
 		}
-		Configs = append(Configs,pv)
+		Configs = append(Configs, pv)
 	}
 	return Configs, nil
 }

--- a/fastbuilder/readline/readline.c
+++ b/fastbuilder/readline/readline.c
@@ -280,6 +280,7 @@ char *fb_command_generator(const char *text, int state) {
 }
 
 const char *flags_pool[]={
+	"--assignnbtdata", "-assignnbtdata", "-nbt"
 	"--excludecommands","-excludecommands",
 	"--invalidatecommands","-invalidatecommands",
 	"--strict","-strict","-S",

--- a/fastbuilder/types/configuration.go
+++ b/fastbuilder/types/configuration.go
@@ -8,9 +8,9 @@ const (
 )
 
 const (
-	TaskTypeSync        = 0
-	TaskTypeAsync       = 1
-	TaskTypeInvalid     = 100
+	TaskTypeSync    = 0
+	TaskTypeAsync   = 1
+	TaskTypeInvalid = 100
 )
 
 const (
@@ -23,7 +23,7 @@ type MainConfig struct {
 	Execute               string
 	Block, OldBlock       *ConstBlock
 	End, Position         Position //Position=Begin
-	ResumeFrom 			  float64
+	ResumeFrom            float64
 	Radius                int
 	Length, Width, Height int
 	MapX, MapZ, MapY      int
@@ -35,70 +35,70 @@ type MainConfig struct {
 }
 
 type DelayConfig struct {
-	Delay                 int64
-	DelayMode             byte
-	DelayThreshold        int
+	Delay          int64
+	DelayMode      byte
+	DelayThreshold int
 }
 
 type GlobalConfig struct {
-	TaskCreationType      byte
-	TaskDisplayMode       byte
+	TaskCreationType byte
+	TaskDisplayMode  byte
 }
 
 func ParseDelayMode(mode string) byte {
 	if mode == "continuous" {
 		return DelayModeContinuous
-	}else if mode=="discrete" {
+	} else if mode == "discrete" {
 		return DelayModeDiscrete
-	}else if mode=="none" {
+	} else if mode == "none" {
 		return DelayModeNone
 	}
 	return DelayModeInvalid
 }
 
 func StrDelayMode(mode byte) string {
-	if mode==DelayModeContinuous {
+	if mode == DelayModeContinuous {
 		return "continuous"
-	}else if mode==DelayModeDiscrete {
+	} else if mode == DelayModeDiscrete {
 		return "discrete"
-	}else if mode==DelayModeNone {
+	} else if mode == DelayModeNone {
 		return "none"
-	}else{
+	} else {
 		return "invalid"
 	}
 }
 
 func ParseTaskType(mode string) byte {
-	if mode=="sync" {
+	if mode == "sync" {
 		return TaskTypeSync
-	}else if mode=="async" {
+	} else if mode == "async" {
 		return TaskTypeAsync
 	}
 	return TaskTypeInvalid
 }
 
 func MakeTaskType(mode byte) string {
-	if mode==TaskTypeSync {
+	if mode == TaskTypeSync {
 		return "sync"
-	}else if mode==TaskTypeAsync {
+	} else if mode == TaskTypeAsync {
 		return "async"
 	}
 	return "invalid"
 }
 
 func ParseTaskDisplayMode(mode string) byte {
-	if mode=="true" {
+	if mode == "true" {
 		return TaskDisplayYes
-	}else if mode=="false" {
+	} else if mode == "false" {
 		return TaskDisplayNo
 	}
 	return TaskDisplayInvalid
 }
 
 func MakeTaskDisplayMode(mode byte) string {
-	if mode==TaskDisplayYes {
+	if mode == TaskDisplayYes {
 		return "true"
-	}else if mode==TaskDisplayNo {
+	} else if mode == TaskDisplayNo {
 		return "false"
 	}
 	return "?"

--- a/fastbuilder/types/configuration.go
+++ b/fastbuilder/types/configuration.go
@@ -29,6 +29,7 @@ type MainConfig struct {
 	MapX, MapZ, MapY      int
 	Method, OldMethod     string
 	Facing, Path, Shape   string
+	AssignNBTData         bool
 	ExcludeCommands       bool
 	InvalidateCommands    bool
 	Strict                bool


### PR DESCRIPTION
## 更改
- 为 `Bdump` 添加了新的 `Flag` ，其名称为 `AssignNBTData` 。当启用时，将会在导入时载入 `方块实体` 数据，否则不载入。特别地，`命令方块` 不会受到此字段的限制，我们永远会为此方块启用数据的写入 _[这么做的目的是为了解决一些潜在性问题，因为未来在载入 `方块实体` 数据时将要求一些比较苛刻的条件，比如用户不能随意移动机器人等]_
  - 内部描述为 `Assign NBT data to blocks by lawful means while importing`
- 修复了一个有关 `get end` 的小问题 _[此问题是在 758cdf618119b98369e391bd8602277307bbeb5e 中发生的]_
- 修复了在导入 `容器` 时无法将物品写入到正确的槽位的问题 _[此问题是在 758cdf618119b98369e391bd8602277307bbeb5e 中发生的]_